### PR TITLE
Story 4.1: Create Open Papers page with external links

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -6,18 +6,27 @@ export interface CardProps {
   link: string
   image?: string
   className?: string
+  external?: boolean
 }
 
-const Card = ({ title, description, link, image, className = '' }: CardProps) => {
+const Card = ({ title, description, link, image, className = '', external = false }: CardProps) => {
   const cardClasses = [
     'card',
     image ? 'card--with-image' : '',
     className,
   ].filter(Boolean).join(' ')
 
+  // Determine if link is external (starts with http:// or https://)
+  const isExternal = external || link.startsWith('http://') || link.startsWith('https://')
+
   return (
     <article className={cardClasses}>
-      <a href={link} className="card__link" aria-label={title}>
+      <a
+        href={link}
+        className="card__link"
+        aria-label={title}
+        {...(isExternal && { target: '_blank', rel: 'noopener noreferrer' })}
+      >
         {image && (
           <div className="card__image-container">
             <img

--- a/src/data/papers.ts
+++ b/src/data/papers.ts
@@ -1,0 +1,34 @@
+// Open Papers data
+// Corresponds to content in content/papers/
+
+export interface Paper {
+  title: string
+  description: string
+  abstract: string
+  externalUrl: string
+  pdfUrl?: string
+  repository: string
+  publicationDate: string
+  lastUpdated: string
+  version: string
+  category: string
+  tags: string[]
+  featured: boolean
+}
+
+export const papers: Paper[] = [
+  {
+    title: 'The Open Source Way 2.0: A Handbook for Community Building',
+    description: 'Comprehensive guide to building and managing open source communities, based on decades of Red Hat community architecture experience.',
+    abstract: 'A comprehensive guide to building and managing open source communities, based on decades of Red Hat community architecture experience. This handbook covers community-building best practices, governance models, contributor onboarding, and sustainable open source program offices (OSPOs).',
+    externalUrl: 'https://github.com/karstenwade/papers/blob/main/open-source-way-2.0.md',
+    pdfUrl: 'https://github.com/karstenwade/papers/releases/download/v2.0/open-source-way.pdf',
+    repository: 'https://github.com/karstenwade/papers',
+    publicationDate: '2020-08-15',
+    lastUpdated: '2024-03-10',
+    version: '2.0',
+    category: 'Community Architecture',
+    tags: ['Open Source', 'Community Management', 'Developer Relations', 'OSPO'],
+    featured: true,
+  },
+]

--- a/src/pages/OpenPapers.css
+++ b/src/pages/OpenPapers.css
@@ -1,0 +1,109 @@
+/* Open Papers Page Styles */
+
+.open-papers {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  padding: var(--space-8) var(--space-4);
+  min-height: 100vh;
+}
+
+/* ===========================
+   Page Header
+   =========================== */
+
+.open-papers__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-width: 800px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.open-papers__title {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  color: var(--color-text-primary);
+}
+
+.open-papers__description {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
+}
+
+.open-papers__repository {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
+  color: var(--color-text-secondary);
+}
+
+.open-papers__repo-link {
+  color: var(--color-primary);
+  text-decoration: underline;
+  font-weight: var(--font-weight-semibold);
+  transition: color var(--transition-fast);
+}
+
+.open-papers__repo-link:hover {
+  color: var(--color-primary-dark);
+}
+
+.open-papers__repo-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ===========================
+   Responsive Breakpoints
+   =========================== */
+
+/* Tablet and Desktop */
+@media (min-width: 769px) {
+  .open-papers {
+    padding: var(--space-12) var(--space-8);
+    gap: var(--space-16);
+  }
+
+  .open-papers__title {
+    font-size: var(--font-size-4xl);
+  }
+
+  .open-papers__description {
+    font-size: var(--font-size-xl);
+  }
+}
+
+/* Large Desktop */
+@media (min-width: 1024px) {
+  .open-papers {
+    padding: var(--space-16) var(--space-12);
+  }
+}
+
+/* ===========================
+   Accessibility
+   =========================== */
+
+/* Reduced motion for users who prefer it */
+@media (prefers-reduced-motion: reduce) {
+  .open-papers__repo-link {
+    transition: none;
+  }
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .open-papers__repo-link {
+    text-decoration-thickness: 2px;
+  }
+}

--- a/src/pages/OpenPapers.test.tsx
+++ b/src/pages/OpenPapers.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import OpenPapers from './OpenPapers'
+
+describe('OpenPapers Page', () => {
+  describe('Page Rendering', () => {
+    it('should render open papers page', () => {
+      render(<OpenPapers />)
+
+      const main = screen.getByRole('main')
+      expect(main).toBeInTheDocument()
+    })
+
+    it('should have correct semantic structure', () => {
+      render(<OpenPapers />)
+
+      const main = screen.getByRole('main')
+      expect(main).toHaveClass('open-papers')
+    })
+  })
+
+  describe('Page Header', () => {
+    it('should render page heading', () => {
+      render(<OpenPapers />)
+
+      const heading = screen.getByRole('heading', { level: 1 })
+      expect(heading).toBeInTheDocument()
+      expect(heading).toHaveTextContent(/Open Papers/i)
+    })
+
+    it('should render page description', () => {
+      render(<OpenPapers />)
+
+      const description = screen.getByText(/research papers/i)
+      expect(description).toBeInTheDocument()
+    })
+
+    it('should mention external repository', () => {
+      render(<OpenPapers />)
+
+      // The repository name appears in a link element
+      expect(screen.getByText(/karstenwade\/papers/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Paper Cards', () => {
+    it('should render at least one paper card', () => {
+      render(<OpenPapers />)
+
+      const cards = screen.getAllByRole('article')
+      expect(cards.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('should use Card component for papers', () => {
+      render(<OpenPapers />)
+
+      const cards = screen.getAllByRole('article')
+      cards.forEach(card => {
+        expect(card).toHaveClass('card')
+      })
+    })
+  })
+
+  describe('Paper Content', () => {
+    it('should display "The Open Source Way 2.0" paper', () => {
+      render(<OpenPapers />)
+
+      expect(screen.getByText(/The Open Source Way 2.0/i)).toBeInTheDocument()
+    })
+
+    it('should display paper descriptions', () => {
+      render(<OpenPapers />)
+
+      expect(screen.getByText(/Comprehensive guide to building and managing/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('External Links', () => {
+    it('should have links to external GitHub repository', () => {
+      render(<OpenPapers />)
+
+      const links = screen.getAllByRole('link')
+      const githubLinks = links.filter(link =>
+        link.getAttribute('href')?.includes('github.com/karstenwade/papers')
+      )
+
+      expect(githubLinks.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('should link to Open Source Way 2.0 on GitHub', () => {
+      render(<OpenPapers />)
+
+      const link = screen.getByRole('link', { name: /The Open Source Way 2.0/i })
+      expect(link).toHaveAttribute('href')
+      expect(link.getAttribute('href')).toContain('github.com/karstenwade/papers')
+    })
+
+    it('should have external link indicators', () => {
+      render(<OpenPapers />)
+
+      // External links should have target="_blank" and rel="noopener noreferrer"
+      const links = screen.getAllByRole('link')
+      const externalLinks = links.filter(link =>
+        link.getAttribute('href')?.includes('github.com')
+      )
+
+      externalLinks.forEach(link => {
+        expect(link).toHaveAttribute('target', '_blank')
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+      })
+    })
+  })
+
+  describe('Responsive Layout', () => {
+    it('should use cards-grid layout', () => {
+      render(<OpenPapers />)
+
+      const grid = document.querySelector('.cards-grid')
+      expect(grid).toBeInTheDocument()
+    })
+
+    it('should contain paper cards in grid', () => {
+      render(<OpenPapers />)
+
+      const cards = screen.getAllByRole('article')
+      const grid = document.querySelector('.cards-grid')
+
+      expect(grid).toContainElement(cards[0])
+    })
+  })
+
+  describe('CSS Classes', () => {
+    it('should apply base open-papers class', () => {
+      render(<OpenPapers />)
+
+      const main = screen.getByRole('main')
+      expect(main).toHaveClass('open-papers')
+    })
+
+    it('should accept custom className prop', () => {
+      render(<OpenPapers className="custom-papers-page" />)
+
+      const main = screen.getByRole('main')
+      expect(main).toHaveClass('open-papers')
+      expect(main).toHaveClass('custom-papers-page')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should use main landmark', () => {
+      render(<OpenPapers />)
+
+      const main = screen.getByRole('main')
+      expect(main).toBeInTheDocument()
+    })
+
+    it('should have h1 as page heading', () => {
+      render(<OpenPapers />)
+
+      const h1 = screen.getByRole('heading', { level: 1 })
+      expect(h1).toBeInTheDocument()
+    })
+
+    it('should have accessible external link indicators', () => {
+      render(<OpenPapers />)
+
+      // External links should have aria-label or screen reader text
+      const externalLinks = screen.getAllByRole('link').filter(link =>
+        link.getAttribute('href')?.includes('github.com')
+      )
+
+      externalLinks.forEach(link => {
+        expect(link).toHaveAttribute('target', '_blank')
+      })
+    })
+  })
+
+  describe('Repository Link', () => {
+    it('should have link to papers repository', () => {
+      render(<OpenPapers />)
+
+      const repoLink = screen.getByRole('link', { name: /karstenwade\/papers/i })
+      expect(repoLink).toHaveAttribute('href', 'https://github.com/karstenwade/papers')
+      expect(repoLink).toHaveAttribute('target', '_blank')
+    })
+  })
+
+  describe('Data Loading', () => {
+    it('should load papers from papers data', () => {
+      render(<OpenPapers />)
+
+      // Should display papers from papers.ts
+      const cards = screen.getAllByRole('article')
+      expect(cards.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('Props Interface', () => {
+    it('should render without any props (using defaults)', () => {
+      render(<OpenPapers />)
+
+      expect(screen.getByRole('main')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
+    })
+
+    it('should accept className prop', () => {
+      render(<OpenPapers className="research-page" />)
+
+      const main = screen.getByRole('main')
+      expect(main).toHaveClass('research-page')
+    })
+  })
+})

--- a/src/pages/OpenPapers.tsx
+++ b/src/pages/OpenPapers.tsx
@@ -1,0 +1,46 @@
+import Card from '../components/Card'
+import { papers } from '../data/papers'
+import './OpenPapers.css'
+
+export interface OpenPapersProps {
+  className?: string
+}
+
+const OpenPapers = ({ className = '' }: OpenPapersProps) => {
+  return (
+    <main className={`open-papers ${className}`}>
+      <div className="open-papers__header">
+        <h1 className="open-papers__title">Open Papers</h1>
+        <p className="open-papers__description">
+          Explore research papers and frameworks on open source community building,
+          developer relations, and collaborative experience.
+        </p>
+        <p className="open-papers__repository">
+          All papers are maintained in the{' '}
+          <a
+            href="https://github.com/karstenwade/papers"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="open-papers__repo-link"
+          >
+            karstenwade/papers
+          </a>{' '}
+          repository.
+        </p>
+      </div>
+
+      <div className="cards-grid">
+        {papers.map((paper) => (
+          <Card
+            key={paper.externalUrl}
+            title={paper.title}
+            description={paper.description}
+            link={paper.externalUrl}
+          />
+        ))}
+      </div>
+    </main>
+  )
+}
+
+export default OpenPapers


### PR DESCRIPTION
## Summary
Implements Story 4.1 from Epic 4: Content Pages

Closes #18

This PR adds the Open Papers page showcasing Karsten's research papers with links to the external GitHub papers repository.

### Files Added
- `src/pages/OpenPapers.tsx` - Page component (45 lines)
- `src/pages/OpenPapers.css` - Page styles (105 lines)
- `src/pages/OpenPapers.test.tsx` - 23 tests (all passing)
- `src/data/papers.ts` - Typed Paper data module

### Files Modified
- `src/components/Card.tsx` - Enhanced to support external links

### Test Results
All 23 tests passing covering page rendering, external links, accessibility

### Acceptance Criteria
- ✅ OpenPapers.tsx page component
- ✅ Card layout linking to github.com/karstenwade/papers
- ✅ Papers list loaded from data
- ✅ External link indicators (target="_blank")
- ✅ Tests passing (23/23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)