### PR TITLE
Epic 7: Branding & Visual Identity

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,15 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+
+    <!-- Favicons -->
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32.png" />
+    <link rel="icon" type="image/png" sizes="48x48" href="/assets/images/favicon-48.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicon-180.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/images/favicon-192.png" />
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Karsten Wade - Collaborative experience consulting, open collaboration expert, and DevEx facilitator" />
     <meta name="keywords" content="collaborative experience consulting, collaboration catalyst, developer experience, DevEx, community catalyst" />

--- a/src/components/Navigation.css
+++ b/src/components/Navigation.css
@@ -10,6 +10,36 @@
   border-bottom: 1px solid var(--color-border-light);
 }
 
+/* Logo styles */
+.navigation__logo {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  transition: opacity var(--transition-fast);
+  border-radius: var(--radius-sm);
+}
+
+.navigation__logo:hover {
+  opacity: 0.8;
+}
+
+.navigation__logo:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.navigation__logo-image {
+  height: 40px;
+  width: auto;
+  display: block;
+}
+
+@media (max-width: 768px) {
+  .navigation__logo-image {
+    height: 32px;
+  }
+}
+
 /* Hamburger button (mobile only) */
 .navigation__hamburger {
   display: none; /* Hidden on desktop */

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -39,6 +39,15 @@ const Navigation = ({ className = '' }: NavigationProps) => {
 
   return (
     <nav className={`navigation ${className}`} aria-label="Main navigation">
+      {/* Logo */}
+      <Link to="/" className="navigation__logo" aria-label="Karsten Wade - Home">
+        <img
+          src="/assets/images/logo.png"
+          alt="Karsten Wade"
+          className="navigation__logo-image"
+        />
+      </Link>
+
       {/* Mobile hamburger button */}
       <button
         className="navigation__hamburger"


### PR DESCRIPTION
## Summary
Implemented complete visual branding for the site including logo, favicon, and headshot image.

## Changes

### Story 7.1: Logo in Header Navigation (#49)
- ✅ Added logo to Navigation component (src/components/Navigation.tsx)
- ✅ Logo links to home page with proper aria-label
- ✅ Responsive sizing: 40px on desktop, 32px on mobile
- ✅ Accessibility: focus states, keyboard navigation
- ✅ Hover effect with opacity transition

### Story 7.2: Favicon and Site Icons (#50)
- ✅ Custom favicon.ico in public/
- ✅ Multiple PNG favicon sizes: 16x16, 32x32, 48x48
- ✅ Apple touch icon: 180x180
- ✅ Android icon: 192x192
- ✅ Updated index.html with all icon link tags
- ✅ Removed default Vite favicon

### Story 7.3: Headshot Image (#51)
- ✅ Hero component configured for headshot display
- ✅ Image at public/assets/images/karsten-wade-headshot.jpg
- ✅ Circular image with primary color border
- ✅ Responsive sizing: 200px mobile → 300px desktop
- ✅ Shadow and hover effects
- ✅ All CSS styling already in place

## Technical Details

**Modified Files:**
- `index.html` - Added favicon links
- `src/components/Navigation.tsx` - Added logo component
- `src/components/Navigation.css` - Added logo styles

**Image Assets (already added to public/assets/images/):**
- logo.png (25 KB)
- karsten-wade-headshot.jpg (458 KB)
- favicon-16.png, favicon-32.png, favicon-48.png
- favicon-180.png (Apple touch icon)
- favicon-192.png (Android)
- favicon.ico (public root)

## Testing
- ✅ Build successful (npm run build)
- ✅ All TypeScript checks pass
- ✅ Responsive design verified
- ✅ Accessibility features working (focus states, aria-labels)

## Closes
- Closes #49 (Story 7.1: Add logo to header navigation)
- Closes #50 (Story 7.2: Add favicon and update site icons)
- Closes #51 (Story 7.3: Add headshot image to Hero component)
- Closes #52 (Epic 7: Branding & Visual Identity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)