### PR TITLE
Fix: Add base path to image URLs for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
 
     <!-- Favicons -->
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32.png" />
-    <link rel="icon" type="image/png" sizes="48x48" href="/assets/images/favicon-48.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/favicon-180.png" />
-    <link rel="icon" type="image/png" sizes="192x192" href="/assets/images/favicon-192.png" />
+    <link rel="icon" type="image/x-icon" href="/karstenwade.com/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/karstenwade.com/assets/images/favicon-16.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/karstenwade.com/assets/images/favicon-32.png" />
+    <link rel="icon" type="image/png" sizes="48x48" href="/karstenwade.com/assets/images/favicon-48.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/karstenwade.com/assets/images/favicon-180.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/karstenwade.com/assets/images/favicon-192.png" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Karsten Wade - Collaborative experience consulting, open collaboration expert, and DevEx facilitator" />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,7 +9,7 @@ const Hero = ({ className = '' }: HeroProps) => {
     <header className={`hero ${className}`} role="banner">
       <div className="hero__image-container">
         <img
-          src="/assets/images/karsten-wade-headshot.jpg"
+          src="/karstenwade.com/assets/images/karsten-wade-headshot.jpg"
           alt="Karsten Wade - Collaborative Experience Consultant"
           className="hero__image"
         />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -42,7 +42,7 @@ const Navigation = ({ className = '' }: NavigationProps) => {
       {/* Logo */}
       <Link to="/" className="navigation__logo" aria-label="Karsten Wade - Home">
         <img
-          src="/assets/images/logo.png"
+          src="/karstenwade.com/assets/images/logo.png"
           alt="Karsten Wade"
           className="navigation__logo-image"
         />


### PR DESCRIPTION
## Problem
Images are not displaying on the deployed GitHub Pages site because the paths don't include the base path.

**Current behavior:**
- Images attempt to load from `https://karstenwade.github.io/assets/images/...`
- This results in 404 errors

**Expected behavior:**
- Images should load from `https://karstenwade.github.io/karstenwade.com/assets/images/...`

## Solution
Added `/karstenwade.com/` base path prefix to all image URLs to match the base path configured in `vite.config.ts`.

## Changes

### Updated Image Paths:
- **Navigation logo:** `/karstenwade.com/assets/images/logo.png`
- **Hero headshot:** `/karstenwade.com/assets/images/karsten-wade-headshot.jpg`
- **Favicon (ico):** `/karstenwade.com/favicon.ico`
- **Favicon 16x16:** `/karstenwade.com/assets/images/favicon-16.png`
- **Favicon 32x32:** `/karstenwade.com/assets/images/favicon-32.png`
- **Favicon 48x48:** `/karstenwade.com/assets/images/favicon-48.png`
- **Apple touch icon:** `/karstenwade.com/assets/images/favicon-180.png`
- **Android icon:** `/karstenwade.com/assets/images/favicon-192.png`

### Files Modified:
- `index.html` - All favicon link tags
- `src/components/Navigation.tsx` - Logo image src
- `src/components/Hero.tsx` - Headshot image src

## Testing
- ✅ Build successful
- ✅ All TypeScript checks pass
- ✅ Image paths now match vite.config.ts base path

## Follow-up from
This fixes the issue identified after PR #53 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)