### PR TITLE
Story #111: Fix test to recognize ES6 shorthand base property syntax

### DIFF
--- a/tests/test-story-1.1.sh
+++ b/tests/test-story-1.1.sh
@@ -201,14 +201,15 @@ else
 fi
 
 # Test 6.2: GitHub Pages compatibility (base path config)
+# Check for both "base:" and shorthand "base," or "base" syntax
 if [ -f "$PROJECT_ROOT/vite.config.ts" ]; then
-    if grep -q "base:" "$PROJECT_ROOT/vite.config.ts"; then
+    if grep -qE "base[,:]|^\s+base\s*$" "$PROJECT_ROOT/vite.config.ts"; then
         test_result "Vite config contains base path for GitHub Pages" "PASS" "PASS"
     else
         test_result "Vite config contains base path for GitHub Pages" "PASS" "FAIL"
     fi
 elif [ -f "$PROJECT_ROOT/vite.config.js" ]; then
-    if grep -q "base:" "$PROJECT_ROOT/vite.config.js"; then
+    if grep -qE "base[,:]|^\s+base\s*$" "$PROJECT_ROOT/vite.config.js"; then
         test_result "Vite config contains base path for GitHub Pages" "PASS" "PASS"
     else
         test_result "Vite config contains base path for GitHub Pages" "PASS" "FAIL"


### PR DESCRIPTION
## Summary

Fixes test-story-1.1.sh Test 6.2 to recognize ES6 shorthand property syntax in vite.config.ts.

## Problem

Test was failing (22/23 passing) because it only checked for explicit `base:` syntax, but vite.config.ts uses ES6 shorthand `base,` (line 16).

## Solution

Updated grep pattern to recognize both syntaxes:
- Explicit: `base:`
- Shorthand: `base,`
- Standalone: `base`

## Changes

**File:** `tests/test-story-1.1.sh`

```bash
# Before
if grep -q "base:" "$PROJECT_ROOT/vite.config.ts"; then

# After
if grep -qE "base[,:]|^\s+base\s*$" "$PROJECT_ROOT/vite.config.ts"; then
```

## Testing

- ✅ All 23/23 tests passing
- ✅ Build succeeds
- ✅ Recognizes both ES6 shorthand and explicit syntax

Closes #111