### PR TITLE
Story #112: Fix linting errors in SEO test and button component

### DIFF
--- a/src/components/SEO.test.tsx
+++ b/src/components/SEO.test.tsx
@@ -86,10 +86,9 @@ describe('SEO Component', () => {
 
   describe('Default Values', () => {
     it('should have default title in props', () => {
-      const title = 'Karsten Wade - Collaborative Experience Consulting'
       const { container } = renderWithHelmet(<SEO />)
       expect(container).toBeTruthy()
-      // Component uses this default title
+      // Component uses default title: 'Karsten Wade - Collaborative Experience Consulting'
     })
 
     it('should have default description mentioning DevEx', () => {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -54,4 +54,5 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 Button.displayName = "Button"
 
+// eslint-disable-next-line react-refresh/only-export-components
 export { Button, buttonVariants }


### PR DESCRIPTION
## Summary

Fixes two ESLint errors to restore clean linting (0 errors, 0 warnings).

## Problems

1. **SEO.test.tsx:89** - Unused variable 'title' declared but never used
2. **button.tsx:57** - react-refresh warning about exporting non-component alongside component

## Solutions

### Fix 1: Remove unused variable

**File:** `src/components/SEO.test.tsx`

Removed unused `title` constant and moved its value to a comment for documentation purposes.

```typescript
// Before
const title = 'Karsten Wade - Collaborative Experience Consulting'
const { container } = renderWithHelmet(<SEO />)

// After  
const { container } = renderWithHelmet(<SEO />)
// Component uses default title: 'Karsten Wade - Collaborative Experience Consulting'
```

### Fix 2: Suppress valid react-refresh warning

**File:** `src/components/ui/button.tsx`

Added eslint-disable comment for buttonVariants export. This is a standard shadcn/ui pattern where both the component and its variants configuration are exported together.

```typescript
// eslint-disable-next-line react-refresh/only-export-components
export { Button, buttonVariants }
```

## Testing

- ✅ All linting checks pass (0 errors, 0 warnings)
- ✅ All 406 unit tests passing
- ✅ Type checking succeeds

Closes #112