### PR TITLE
feat(story-14.2): Migrate shared components to Next.js App Router

### DIFF
--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -1,0 +1,56 @@
+import { Card as ShadcnCard, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+export interface CardProps {
+  title: string
+  description: string
+  link: string
+  image?: string
+  className?: string
+  external?: boolean
+}
+
+const Card = ({ title, description, link, image, className = '', external = false }: CardProps) => {
+  // Determine if link is external (starts with http:// or https://)
+  const isExternal = external || link.startsWith('http://') || link.startsWith('https://')
+
+  return (
+    <article className={cn('card', image && 'card--with-image', className)}>
+      <a
+        href={link}
+        className="block no-underline text-inherit hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 rounded-xl transition-all"
+        aria-label={title}
+        {...(isExternal && { target: '_blank', rel: 'noopener noreferrer' })}
+      >
+        <ShadcnCard className="h-full transition-all duration-200 hover:shadow-lg hover:scale-[1.02] border-gray-200">
+          {image && (
+            <div className="card__image-container overflow-hidden rounded-t-xl">
+              <img
+                src={image}
+                alt={title}
+                className="card__image w-full h-48 object-cover transition-transform duration-200 hover:scale-105"
+                loading="lazy"
+              />
+            </div>
+          )}
+          <CardHeader className={cn(!image && 'pt-6')}>
+            <CardTitle className="card__title">
+              <h3 className="text-xl font-semibold leading-tight tracking-tight">
+                {title}
+              </h3>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="card__content pt-0">
+            <CardDescription>
+              <p className="card__description text-sm text-gray-600">
+                {description}
+              </p>
+            </CardDescription>
+          </CardContent>
+        </ShadcnCard>
+      </a>
+    </article>
+  )
+}
+
+export default Card

--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -1,0 +1,172 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+
+interface NavigationProps {
+  className?: string
+}
+
+const Navigation = ({ className = '' }: NavigationProps) => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const toggleMenu = () => {
+    setIsMenuOpen(!isMenuOpen)
+  }
+
+  const closeMenu = () => {
+    setIsMenuOpen(false)
+  }
+
+  // Handle keyboard navigation for menu toggle
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      toggleMenu()
+    }
+    // Close menu on Escape
+    if (e.key === 'Escape' && isMenuOpen) {
+      closeMenu()
+    }
+  }
+
+  const navLinks = [
+    { name: 'Home', href: '/' },
+    { name: 'Open Papers', href: '/papers' },
+    { name: 'Writing', href: '/writing' },
+    { name: 'CV', href: '/cv' },
+  ]
+
+  return (
+    <nav
+      className={cn(
+        "relative flex flex-col md:flex-col p-4",
+        "bg-[var(--color-bg-primary)] border-b border-[var(--color-border-light)]",
+        className
+      )}
+      aria-label="Main navigation"
+    >
+      {/* Header row with logo and hamburger */}
+      <div className="flex items-center justify-between w-full mb-0 md:mb-2">
+        {/* Logo */}
+        <Link
+          href="/"
+          className={cn(
+            "flex items-center no-underline",
+            "transition-opacity duration-200 rounded-sm",
+            "hover:opacity-80",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2"
+          )}
+          aria-label="Karsten Wade - Home"
+        >
+          <img
+            src="/assets/images/logo.png"
+            alt="Karsten Wade"
+            className="h-10 md:h-10 w-auto block"
+          />
+        </Link>
+
+        {/* Mobile hamburger button */}
+        <button
+        className={cn(
+          "hidden md:hidden flex-col justify-center items-center",
+          "w-11 h-11 p-2",
+          "bg-transparent border-2 border-[var(--color-neutral-400)] rounded-sm",
+          "cursor-pointer transition-all duration-200 z-[var(--z-sticky)]",
+          "hover:border-[var(--color-primary)] hover:bg-[var(--color-neutral-100)]",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2 focus-visible:border-[var(--color-primary)]",
+          "active:bg-[var(--color-neutral-200)]",
+          "max-md:flex"
+        )}
+        onClick={toggleMenu}
+        onKeyDown={handleKeyDown}
+        aria-expanded={isMenuOpen}
+        aria-controls="navigation-menu"
+        aria-label={isMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+        type="button"
+      >
+        <span className={cn(
+          "flex flex-col w-5",
+          isMenuOpen ? "gap-0" : "gap-1"
+        )} aria-hidden="true">
+          <span className={cn(
+            "block w-full h-0.5 bg-[var(--color-neutral-700)]",
+            "transition-all duration-300",
+            "motion-reduce:transition-none",
+            isMenuOpen && "rotate-45 translate-y-0.5"
+          )}></span>
+          <span className={cn(
+            "block w-full h-0.5 bg-[var(--color-neutral-700)]",
+            "transition-all duration-300",
+            "motion-reduce:transition-none",
+            isMenuOpen && "opacity-0"
+          )}></span>
+          <span className={cn(
+            "block w-full h-0.5 bg-[var(--color-neutral-700)]",
+            "transition-all duration-300",
+            "motion-reduce:transition-none",
+            isMenuOpen && "-rotate-45 -translate-y-0.5"
+          )}></span>
+        </span>
+      </button>
+      </div>
+
+      {/* Navigation menu - below header, flush left on desktop */}
+      <ul
+        id="navigation-menu"
+        className={cn(
+          // Always flex (visible on desktop, positioned off-screen on mobile)
+          "flex flex-row gap-6 list-none m-0 p-0",
+          // Mobile - fixed sidebar (hidden via translate)
+          "max-md:fixed max-md:top-0 max-md:right-0 max-md:bottom-0",
+          "max-md:flex-col max-md:gap-0",
+          "max-md:w-[280px] max-md:max-w-[80vw]",
+          "max-md:pt-16 max-md:px-4 max-md:pb-8",
+          "max-md:bg-[var(--color-bg-primary)]",
+          "max-md:border-l max-md:border-[var(--color-border-medium)]",
+          "max-md:shadow-[var(--shadow-xl)]",
+          "max-md:z-[var(--z-fixed)]",
+          "max-md:overflow-y-auto",
+          // Mobile - slide animation
+          "max-md:transition-transform max-md:duration-300",
+          "max-md:motion-reduce:transition-none",
+          isMenuOpen ? "max-md:translate-x-0" : "max-md:translate-x-full"
+        )}
+        role="list"
+      >
+        {navLinks.map((link, index) => (
+          <li
+            key={link.href}
+            className={cn(
+              "m-0",
+              "max-md:border-b max-md:border-[var(--color-border-light)]",
+              index === navLinks.length - 1 && "max-md:border-b-0"
+            )}
+          >
+            <Link
+              href={link.href}
+              className={cn(
+                "block px-3 py-2",
+                "font-[var(--font-body)] text-base font-medium",
+                "text-[var(--color-text-primary)] no-underline",
+                "rounded-sm transition-all duration-200",
+                "motion-reduce:transition-none",
+                "hover:text-[var(--color-primary)] hover:bg-[var(--color-neutral-100)] hover:no-underline",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-2",
+                "active:bg-[var(--color-neutral-200)]",
+                "md:whitespace-nowrap",
+                "max-md:px-4 max-md:py-4 max-md:text-base"
+              )}
+              onClick={closeMenu}
+            >
+              {link.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
+
+export default Navigation

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,54 @@
+import Navigation from './components/Navigation'
+import Card from './components/Card'
+
 export default function Home() {
+  const featuredCards = [
+    {
+      title: 'Open Papers',
+      description: 'Papers and frameworks on open source community building, developer relations, and collaborative developer experience.',
+      link: '/papers',
+    },
+    {
+      title: 'Writing',
+      description: 'Poetry, essays, and prose exploring themes of collaboration, technology, and human connection.',
+      link: '/writing',
+    },
+    {
+      title: 'CV',
+      description: 'Professional experience in open source community building and developer relations.',
+      link: '/cv',
+    },
+  ]
+
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center p-8">
-      <div className="max-w-2xl text-center">
-        <h1 className="text-4xl font-semibold text-neutral-800 mb-4">
-          Karsten Wade
-        </h1>
-        <p className="text-xl text-neutral-600 mb-8">
-          Collaborative Experience Consulting
-        </p>
-        <p className="text-neutral-500">
-          Next.js migration in progress. This page confirms the Next.js App
-          Router is working correctly.
-        </p>
-      </div>
-    </main>
+    <>
+      <Navigation />
+      <main className="min-h-screen flex flex-col items-center p-8">
+        <div className="max-w-4xl w-full">
+          <div className="text-center mb-12">
+            <h1 className="text-4xl font-semibold text-neutral-800 mb-4">
+              Karsten Wade
+            </h1>
+            <p className="text-xl text-neutral-600 mb-8">
+              Collaborative Experience Consulting
+            </p>
+            <p className="text-neutral-500 mb-8">
+              Building communities and enabling collaboration through open source principles.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {featuredCards.map((card) => (
+              <Card
+                key={card.link}
+                title={card.title}
+                description={card.description}
+                link={card.link}
+              />
+            ))}
+          </div>
+        </div>
+      </main>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- Create Next.js Navigation component with `'use client'` directive and `next/link`
- Create Next.js Card component as Server Component reusing Shadcn UI via `@/` alias
- Update `app/page.tsx` to use migrated components with featured content cards

## Test plan
- [x] Next.js build passes (`npm run build:next`)
- [x] TypeScript type check passes (`npm run type-check`)
- [x] All 397 unit tests pass (`npm run test:unit`)
- [ ] Manual verification at http://localhost:3001

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)