### PR TITLE
feat(story-14.5): Migrate SEO to Next.js Metadata API

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,30 @@
 import type { Metadata } from 'next'
+import Script from 'next/script'
 import './globals.css'
+
+// Person JSON-LD for site-wide structured data
+const personJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Karsten Wade',
+  jobTitle: 'Collaborative Experience Consultant',
+  description: 'Collaboration catalyst and open collaboration expert specializing in developer experience (DevEx) and community building',
+  url: 'https://karstenwade.com',
+  image: 'https://karstenwade.com/assets/images/karsten-wade-headshot.jpg',
+  sameAs: [
+    'https://github.com/quaid',
+    'https://linkedin.com/in/karstenwade',
+    'https://fosstodon.org/@quaid',
+  ],
+  knowsAbout: [
+    'Developer Experience',
+    'Open Source',
+    'Community Architecture',
+    'Collaborative Work',
+    'OSPO',
+    'The Open Source Way',
+  ],
+}
 
 export const metadata: Metadata = {
   title: {
@@ -49,7 +74,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Script
+          id="person-jsonld"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        />
+        {children}
+      </body>
     </html>
   )
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,5 +1,15 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import Navigation from './components/Navigation'
+
+export const metadata: Metadata = {
+  title: 'Page Not Found',
+  description: 'The requested page could not be found.',
+  robots: {
+    index: false,
+    follow: true,
+  },
+}
 
 export default function NotFound() {
   return (


### PR DESCRIPTION
## Summary
- Add Person JSON-LD structured data to root layout for site-wide SEO
- Add metadata to not-found.tsx with noindex directive
- Root layout already has comprehensive metadata (title template, OG, Twitter)
- All pages export appropriate metadata including dynamic `generateMetadata` for paper details
- react-helmet-async kept during migration (still used by Vite app in src/)

## Acceptance Criteria
- [x] Root layout exports metadata with site defaults
- [x] Each page exports appropriate metadata
- [x] Dynamic metadata for paper detail pages using `generateMetadata`
- [x] Open Graph tags configured
- [x] Twitter Card tags configured
- [x] Structured data (JSON-LD) implemented
- [x] Canonical URLs set correctly (via metadataBase)
- [ ] react-helmet-async removed from dependencies (deferred - still needed for Vite)

## Test plan
- [x] Build passes with all 7 static pages generated
- [ ] View source to verify JSON-LD appears in HTML
- [ ] Test OG tags with social media debuggers after deployment

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)