### PR TITLE
feat(story-14.6): Configure static export and deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,15 +31,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build static site
-        run: npm run build
-        env:
-          GITHUB_PAGES: true
+      - name: Build Next.js static site
+        run: npm run build:next
 
       - name: Upload build artifacts
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./dist
+          path: ./out
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- Update deploy.yml workflow to build Next.js static site
- Change from `npm run build` (Vite) to `npm run build:next` (Next.js)
- Change artifact path from `./dist` to `./out`
- next.config.ts already has `output: 'export'` configured

## Acceptance Criteria
- [x] `next.config.js` configured with `output: 'export'`
- [x] `next build` generates static `out/` directory
- [x] All pages render as static HTML (7 pages)
- [x] Assets optimized and hashed
- [x] GitHub Pages deployment configured
- [ ] Custom domain working (verify after deploy)
- [ ] HTTPS enabled (verify after deploy)

## Test plan
- [x] `npm run build:next` generates out/ directory
- [x] Tested locally with `npx serve out`
- [ ] Verify GitHub Pages deployment after merge

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)