### PR TITLE
fix(story-158): Fix content expansion duplication in cards

### DIFF
--- a/app/components/EssaysList.tsx
+++ b/app/components/EssaysList.tsx
@@ -62,12 +62,17 @@ export default function EssaysList({ essays, className = '' }: EssaysListProps) 
               <div className="essay-preview__theme text-gray-600 italic mb-4">{essay.theme}</div>
 
               <div className="essay-preview__content">
-                <div className="essay-preview__excerpt text-gray-700 leading-relaxed">
-                  {essay.excerpt}
-                </div>
-
-                {isExpanded && (
-                  <div className="essay-preview__full-text mt-4 pt-4 border-t border-gray-200 space-y-4">
+                {!isExpanded ? (
+                  <div className="essay-preview__excerpt text-gray-700 leading-relaxed space-y-4">
+                    {/* Show first 2 paragraphs as preview with original formatting */}
+                    {essay.fullText.split('\n\n').slice(0, 2).map((paragraph, idx) => (
+                      <p key={idx} className="essay-paragraph">
+                        {paragraph}
+                      </p>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="essay-preview__full-text space-y-4">
                     {essay.fullText.split('\n\n').map((paragraph, idx) => (
                       <p key={idx} className="essay-paragraph text-gray-700 leading-relaxed">
                         {paragraph}

--- a/app/components/FictionList.tsx
+++ b/app/components/FictionList.tsx
@@ -62,12 +62,17 @@ export default function FictionList({ stories, className = '' }: FictionListProp
               </div>
 
               <div className="story-preview__content">
-                <div className="story-preview__excerpt text-gray-700 leading-relaxed">
-                  {story.excerpt}
-                </div>
-
-                {isExpanded && (
-                  <div className="story-preview__full-text mt-4 pt-4 border-t border-gray-200 space-y-4">
+                {!isExpanded ? (
+                  <div className="story-preview__excerpt text-gray-700 leading-relaxed space-y-4">
+                    {/* Show first 2 paragraphs as preview with original formatting */}
+                    {story.fullText.split('\n\n').slice(0, 2).map((paragraph, idx) => (
+                      <p key={idx} className="story-paragraph">
+                        {paragraph}
+                      </p>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="story-preview__full-text space-y-4">
                     {story.fullText.split('\n\n').map((paragraph, idx) => (
                       <p key={idx} className="story-paragraph text-gray-700 leading-relaxed">
                         {paragraph}

--- a/app/components/PoetryList.tsx
+++ b/app/components/PoetryList.tsx
@@ -59,16 +59,16 @@ export default function PoetryList({ poems, className = '' }: PoetryListProps) {
               <div className="poem-preview__theme text-gray-600 italic mb-4">{poem.theme}</div>
 
               <div className="poem-preview__content">
-                <div className="poem-preview__excerpt text-gray-700 leading-relaxed">
-                  {poem.excerpt.split('\n').map((line, idx) => (
-                    <div key={idx} className="poem-line whitespace-pre-wrap min-h-[1.75em]">
-                      {line || '\u00A0'}{/* Non-breaking space for empty lines (stanza breaks) */}
-                    </div>
-                  ))}
-                </div>
-
-                {isExpanded && (
-                  <div className="poem-preview__full-text mt-4 pt-4 border-t border-gray-200 text-gray-700 leading-relaxed">
+                {!isExpanded ? (
+                  <div className="poem-preview__excerpt text-gray-700 leading-relaxed">
+                    {poem.excerpt.split('\n').map((line, idx) => (
+                      <div key={idx} className="poem-line whitespace-pre-wrap min-h-[1.75em]">
+                        {line || '\u00A0'}{/* Non-breaking space for empty lines (stanza breaks) */}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="poem-preview__full-text text-gray-700 leading-relaxed">
                     {poem.fullText.split('\n').map((line, idx) => (
                       <div key={idx} className="poem-line whitespace-pre-wrap min-h-[1.75em]">
                         {line || '\u00A0'}{/* Non-breaking space for empty lines (stanza breaks) */}

--- a/src/components/Essays.test.tsx
+++ b/src/components/Essays.test.tsx
@@ -190,13 +190,13 @@ describe('Essays Component', () => {
         expect(toggleButtons.length).toBeGreaterThan(0)
       })
 
-      // Full text (beyond excerpt) should not be visible initially
-      expect(screen.queryByText(/Sharing it rough and raw, sharing it polished and poised/i)).not.toBeInTheDocument()
+      // Text from paragraph 3+ (beyond the 2-paragraph preview) should not be visible initially
+      expect(screen.queryByText(/A long time ago maybe, I decided/i)).not.toBeInTheDocument()
 
       await user.click(toggleButtons![0])
 
-      // Full text should now be visible
-      expect(screen.getByText(/Sharing it rough and raw, sharing it polished and poised/i)).toBeInTheDocument()
+      // Full text (including paragraph 3+) should now be visible
+      expect(screen.getByText(/A long time ago maybe, I decided/i)).toBeInTheDocument()
     })
 
     it('should allow expanding multiple essays simultaneously', async () => {

--- a/src/components/Essays.tsx
+++ b/src/components/Essays.tsx
@@ -70,11 +70,16 @@ const Essays = ({ className = '' }: EssaysProps) => {
               <div className="essay-preview__theme">{essay.theme}</div>
 
               <div className="essay-preview__content">
-                <div className="essay-preview__excerpt">
-                  {essay.excerpt}
-                </div>
-
-                {isExpanded && (
+                {!isExpanded ? (
+                  <div className="essay-preview__excerpt">
+                    {/* Show first 2 paragraphs as preview with original formatting */}
+                    {essay.fullText.split('\n\n').slice(0, 2).map((paragraph, idx) => (
+                      <p key={idx} className="essay-paragraph">
+                        {paragraph}
+                      </p>
+                    ))}
+                  </div>
+                ) : (
                   <div className="essay-preview__full-text">
                     {essay.fullText.split('\n\n').map((paragraph, idx) => (
                       <p key={idx} className="essay-paragraph">

--- a/src/components/Fiction.tsx
+++ b/src/components/Fiction.tsx
@@ -70,11 +70,16 @@ const Fiction = ({ className = '' }: FictionProps) => {
               </div>
 
               <div className="story-preview__content">
-                <div className="story-preview__excerpt">
-                  {story.excerpt}
-                </div>
-
-                {isExpanded && (
+                {!isExpanded ? (
+                  <div className="story-preview__excerpt">
+                    {/* Show first 2 paragraphs as preview with original formatting */}
+                    {story.fullText.split('\n\n').slice(0, 2).map((paragraph, idx) => (
+                      <p key={idx} className="story-paragraph">
+                        {paragraph}
+                      </p>
+                    ))}
+                  </div>
+                ) : (
                   <div className="story-preview__full-text">
                     {story.fullText.split('\n\n').map((paragraph, idx) => (
                       <p key={idx} className="story-paragraph">

--- a/src/components/Poetry.tsx
+++ b/src/components/Poetry.tsx
@@ -67,19 +67,19 @@ const Poetry = ({ className = '' }: PoetryProps) => {
               <div className="poem-preview__theme">{poem.theme}</div>
 
               <div className="poem-preview__content">
-                <div className="poem-preview__excerpt">
-                  {poem.excerpt.split('\n').map((line, idx) => (
-                    <div key={idx} className="poem-line">
-                      {line}
-                    </div>
-                  ))}
-                </div>
-
-                {isExpanded && (
+                {!isExpanded ? (
+                  <div className="poem-preview__excerpt">
+                    {poem.excerpt.split('\n').map((line, idx) => (
+                      <div key={idx} className="poem-line">
+                        {line || '\u00A0'}{/* Non-breaking space for empty lines (stanza breaks) */}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
                   <div className="poem-preview__full-text">
                     {poem.fullText.split('\n').map((line, idx) => (
                       <div key={idx} className="poem-line">
-                        {line}
+                        {line || '\u00A0'}{/* Non-breaking space for empty lines (stanza breaks) */}
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
## Summary

- **Bug Fix**: Content cards (Poetry, Essays, Fiction) were duplicating preview content when expanded
- **Poetry**: Excerpt lines were shown, then the full poem duplicated those lines below
- **Essays**: Preview was reformatted/condensed, then full text duplicated content
- **Fiction**: Same duplication issue prepared for when content is added

## Solution

Changed all list components to use conditional rendering:
- **Collapsed**: Show excerpt/preview only
- **Expanded**: Show fullText only (replaces preview, no duplication)

Essays and Fiction now show first 2 paragraphs with original formatting as preview, ensuring fidelity to the source content.

## Files Changed

- `app/components/PoetryList.tsx` - Fixed expansion logic
- `app/components/EssaysList.tsx` - Fixed expansion + better preview formatting
- `app/components/FictionList.tsx` - Fixed expansion + better preview formatting
- `src/components/Poetry.tsx` - Vite version fixed
- `src/components/Essays.tsx` - Vite version fixed
- `src/components/Fiction.tsx` - Vite version fixed
- `src/components/Essays.test.tsx` - Updated test expectations

## Test plan

- [x] All 436 tests pass
- [x] Build succeeds
- [x] Poetry expansion shows complete poem without duplication
- [x] Essays expansion shows full essay without duplication
- [x] Fiction prepared for same pattern when content is added

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)