### PR TITLE
fix(story-155): Update featured card links to use internal pages

### DIFF
--- a/src/components/FeaturedContent.test.tsx
+++ b/src/components/FeaturedContent.test.tsx
@@ -91,20 +91,21 @@ describe('FeaturedContent Component', () => {
       expect(links.length).toBeGreaterThanOrEqual(2)
     })
 
-    it('should link to featured paper on GitHub', () => {
+    it('should link to internal paper page', () => {
       render(<FeaturedContent />)
 
       const link = screen.getByRole('link', { name: /Understanding Collaborative Experience/i })
       expect(link).toHaveAttribute('href')
-      expect(link.getAttribute('href')).toContain('github.com/karstenwade/papers')
+      // Should link to internal paper page, not external GitHub
+      expect(link.getAttribute('href')).toBe('/papers/Understanding_Collaborative_Experience--CollabX--and_Contributor_Experience--ContribX')
     })
 
-    it('should link to Writing page for poetry', () => {
+    it('should link to Writing page with anchor for poetry', () => {
       render(<FeaturedContent />)
 
       // The link accessible name comes from the card title "Poetry"
       const link = screen.getByRole('link', { name: /Poetry/i })
-      expect(link).toHaveAttribute('href', '/writing')
+      expect(link).toHaveAttribute('href', '/writing#bonn-cemetery-alter-friedhof')
     })
   })
 

--- a/src/components/FeaturedContent.tsx
+++ b/src/components/FeaturedContent.tsx
@@ -1,6 +1,5 @@
 import Card from './Card'
 import { featuredItems, maxFeatured } from '../data/featuredContent'
-import { papers } from '../data/papers'
 import './FeaturedContent.css'
 
 export interface FeaturedContentProps {
@@ -13,18 +12,20 @@ const FeaturedContent = ({ className = '' }: FeaturedContentProps) => {
     .sort((a, b) => a.priority - b.priority)
     .slice(0, maxFeatured)
 
-  // Get the correct URL for each featured item
+  // Get the internal URL for each featured item
   const getItemPath = (type: string, slug: string): string => {
-    // For papers, use the external URL if available
+    // For papers, link to internal paper page
     if (type === 'paper') {
-      const paper = papers.find(p => p.slug === slug)
-      if (paper?.externalUrl) {
-        return paper.externalUrl
-      }
+      return `/papers/${slug}`
     }
 
-    // For poems and writing, just link to the Writing page
-    if (type === 'poem' || type === 'writing') {
+    // For poems, link to Writing page with anchor
+    if (type === 'poem') {
+      return `/writing#${slug}`
+    }
+
+    // For general writing, link to Writing page
+    if (type === 'writing') {
       return '/writing'
     }
 


### PR DESCRIPTION
## Summary

- Featured paper cards now link to `/papers/[slug]` instead of external GitHub URLs
- Featured poetry cards now link to `/writing#[slug]` with anchor for direct navigation
- Removes unused `papers` import from FeaturedContent component

## Why

Featured work cards on the Home page were linking directly to GitHub, creating a jarring experience when users clicked them. Now users stay on karstenwade.com for a seamless experience.

## Files Changed

- `src/components/FeaturedContent.tsx` - Updated link generation logic
- `src/components/FeaturedContent.test.tsx` - Updated tests to verify internal links

## Test plan

- [x] All 436 tests pass
- [x] Paper cards link to `/papers/[slug]`
- [x] Poetry cards link to `/writing#[slug]`
- [x] GitHub links remain available on destination pages

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)