### PR TITLE
feat(blog): Add filtering and pagination for blog listing (#179)

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,282 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { strapiClient } from '@/lib/strapi'
+import Navigation from '../../components/Navigation'
+import StructuredData from '../../components/StructuredData'
+
+interface BlogPostDetailProps {
+  params: Promise<{ slug: string }>
+}
+
+// Disable dynamic params - only pre-rendered paths are valid
+export const dynamicParams = false
+
+// Generate static params for all blog posts at build time
+export async function generateStaticParams(): Promise<Array<{ slug: string }>> {
+  try {
+    const { posts } = await strapiClient.getBlogPosts({ limit: 100 })
+    // If no posts, return a placeholder that will 404
+    if (posts.length === 0) {
+      return [{ slug: '__placeholder__' }]
+    }
+    return posts.map((post) => ({
+      slug: post.slug,
+    }))
+  } catch {
+    // Return placeholder on error
+    return [{ slug: '__placeholder__' }]
+  }
+}
+
+// Generate metadata for each blog post
+export async function generateMetadata({ params }: BlogPostDetailProps): Promise<Metadata> {
+  const { slug } = await params
+  const post = await strapiClient.getBlogPostBySlug(slug)
+
+  if (!post) {
+    return {
+      title: 'Post Not Found - Karsten Wade',
+    }
+  }
+
+  return {
+    title: `${post.title} - Karsten Wade`,
+    description: post.excerpt,
+    keywords: [...(post.tags || []), 'blog', post.category].filter(Boolean) as string[],
+    authors: [{ name: post.author || 'Karsten Wade' }],
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      type: 'article',
+      url: `https://karstenwade.com/blog/${slug}`,
+      publishedTime: post.published_at || undefined,
+      modifiedTime: post.updated_at,
+      authors: [post.author || 'Karsten Wade'],
+      tags: post.tags,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.title,
+      description: post.excerpt,
+    },
+  }
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return ''
+  const date = new Date(dateStr)
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export default async function BlogPostDetail({ params }: BlogPostDetailProps) {
+  const { slug } = await params
+  const post = await strapiClient.getBlogPostBySlug(slug)
+
+  if (!post) {
+    notFound()
+  }
+
+  return (
+    <>
+      <Navigation />
+      <StructuredData type="blog" data={post} />
+
+      <main className="blog-post max-w-4xl mx-auto px-4 py-8">
+        <nav className="blog-post__breadcrumb mb-6">
+          <Link
+            href="/blog"
+            className="text-blue-600 hover:underline"
+          >
+            &larr; Back to Blog
+          </Link>
+        </nav>
+
+        <article className="blog-post__article">
+          <header className="blog-post__header mb-8">
+            <h1 className="blog-post__title text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+              {post.title}
+            </h1>
+
+            <div className="blog-post__meta flex flex-wrap gap-4 text-sm text-gray-600 mb-4">
+              {post.category && (
+                <span className="blog-post__category bg-blue-100 text-blue-800 px-3 py-1 rounded-full">
+                  {post.category}
+                </span>
+              )}
+              <span className="blog-post__reading-time">
+                {post.reading_time} min read
+              </span>
+              <time className="blog-post__date" dateTime={post.published_at || post.created_at}>
+                {formatDate(post.published_at || post.created_at)}
+              </time>
+            </div>
+
+            {post.author && (
+              <p className="blog-post__author text-gray-600 mb-4">
+                By <span className="font-medium">{post.author}</span>
+              </p>
+            )}
+
+            {post.tags && post.tags.length > 0 && (
+              <div className="blog-post__tags flex flex-wrap gap-2 mb-6">
+                {post.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="blog-post__tag bg-gray-100 text-gray-700 px-3 py-1 rounded-full text-sm"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {post.excerpt && (
+              <p className="blog-post__excerpt text-lg text-gray-700 leading-relaxed mb-6 italic border-l-4 border-blue-500 pl-4">
+                {post.excerpt}
+              </p>
+            )}
+          </header>
+
+          {/* Blog post content rendered from markdown */}
+          {post.content && (
+            <section className="blog-post__content prose prose-lg max-w-none mb-8">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  // Style headings
+                  h1: ({ children }) => (
+                    <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4 border-b pb-2">
+                      {children}
+                    </h2>
+                  ),
+                  h2: ({ children }) => (
+                    <h3 className="text-xl font-semibold text-gray-800 mt-6 mb-3">
+                      {children}
+                    </h3>
+                  ),
+                  h3: ({ children }) => (
+                    <h4 className="text-lg font-medium text-gray-700 mt-4 mb-2">
+                      {children}
+                    </h4>
+                  ),
+                  // Style paragraphs
+                  p: ({ children }) => (
+                    <p className="text-gray-700 leading-relaxed mb-4">
+                      {children}
+                    </p>
+                  ),
+                  // Style lists
+                  ul: ({ children }) => (
+                    <ul className="list-disc list-inside mb-4 space-y-1 text-gray-700">
+                      {children}
+                    </ul>
+                  ),
+                  ol: ({ children }) => (
+                    <ol className="list-decimal list-inside mb-4 space-y-1 text-gray-700">
+                      {children}
+                    </ol>
+                  ),
+                  // Style links
+                  a: ({ href, children }) => (
+                    <a
+                      href={href}
+                      className="text-blue-600 hover:underline"
+                      target={href?.startsWith('http') ? '_blank' : undefined}
+                      rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
+                    >
+                      {children}
+                    </a>
+                  ),
+                  // Style blockquotes
+                  blockquote: ({ children }) => (
+                    <blockquote className="border-l-4 border-blue-500 pl-4 my-4 italic text-gray-600">
+                      {children}
+                    </blockquote>
+                  ),
+                  // Style code blocks
+                  code: ({ className, children }) => {
+                    const isInline = !className
+                    if (isInline) {
+                      return (
+                        <code className="bg-gray-100 px-1 py-0.5 rounded text-sm font-mono">
+                          {children}
+                        </code>
+                      )
+                    }
+                    return (
+                      <code className="block bg-gray-100 p-4 rounded-lg overflow-x-auto text-sm font-mono">
+                        {children}
+                      </code>
+                    )
+                  },
+                  // Style tables
+                  table: ({ children }) => (
+                    <div className="overflow-x-auto mb-4">
+                      <table className="min-w-full border-collapse border border-gray-300">
+                        {children}
+                      </table>
+                    </div>
+                  ),
+                  th: ({ children }) => (
+                    <th className="border border-gray-300 px-4 py-2 bg-gray-100 font-semibold text-left">
+                      {children}
+                    </th>
+                  ),
+                  td: ({ children }) => (
+                    <td className="border border-gray-300 px-4 py-2">
+                      {children}
+                    </td>
+                  ),
+                }}
+              >
+                {post.content}
+              </ReactMarkdown>
+            </section>
+          )}
+
+          <footer className="blog-post__footer pt-6 border-t border-gray-200">
+            {post.updated_at && post.updated_at !== post.published_at && (
+              <p className="blog-post__updated text-sm text-gray-500 mb-4">
+                Last updated:{' '}
+                <time dateTime={post.updated_at}>
+                  {formatDate(post.updated_at)}
+                </time>
+              </p>
+            )}
+
+            <div className="blog-post__share">
+              <p className="text-gray-600 mb-2">Share this post:</p>
+              <div className="flex gap-4">
+                <a
+                  href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(post.title)}&url=${encodeURIComponent(`https://karstenwade.com/blog/${post.slug}`)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-500 hover:text-blue-600"
+                  aria-label="Share on Twitter"
+                >
+                  Twitter
+                </a>
+                <a
+                  href={`https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(`https://karstenwade.com/blog/${post.slug}`)}&title=${encodeURIComponent(post.title)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-700 hover:text-blue-800"
+                  aria-label="Share on LinkedIn"
+                >
+                  LinkedIn
+                </a>
+              </div>
+            </div>
+          </footer>
+        </article>
+      </main>
+    </>
+  )
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import Navigation from '../components/Navigation'
+import BlogListClient from '../components/BlogListClient'
+import { strapiClient } from '@/lib/strapi'
+
+export const metadata: Metadata = {
+  title: 'Blog - Karsten Wade',
+  description: 'Thoughts on open source, community building, AI collaboration, and technology',
+  keywords: ['blog', 'open source', 'community', 'AI', 'technology', 'Karsten Wade'],
+  openGraph: {
+    url: 'https://karstenwade.com/blog',
+  },
+}
+
+// Server Component - data fetched at build time
+export default async function Blog() {
+  // Fetch all blog posts for client-side filtering
+  const { posts } = await strapiClient.getBlogPosts({ limit: 100 })
+
+  return (
+    <>
+      <Navigation />
+      <main id="main-content" className="blog max-w-4xl mx-auto px-4 py-8">
+        <div className="blog__header text-center mb-8">
+          <h1 className="blog__title text-4xl font-bold text-gray-900 mb-2">Blog</h1>
+          <p className="blog__description text-xl text-gray-600">
+            Thoughts on open source, community building, and technology
+          </p>
+        </div>
+
+        {posts.length > 0 ? (
+          /* Client component handles filtering, pagination, and URL state */
+          <Suspense fallback={<div className="text-center py-8">Loading posts...</div>}>
+            <BlogListClient posts={posts} postsPerPage={10} />
+          </Suspense>
+        ) : (
+          /* Empty state when no posts */
+          <div className="blog__empty text-center py-16">
+            <div className="bg-gray-50 rounded-lg p-8 border border-gray-200">
+              <h2 className="text-2xl font-semibold text-gray-700 mb-4">Coming Soon</h2>
+              <p className="text-gray-600 mb-4">
+                Blog posts are being migrated to a new CMS-powered system.
+              </p>
+              <p className="text-gray-500 text-sm">
+                In the meantime, check out my{' '}
+                <a href="/papers" className="text-blue-600 hover:underline">Open Papers</a>
+                {' '}or{' '}
+                <a href="/writing" className="text-blue-600 hover:underline">Writing</a>.
+              </p>
+            </div>
+          </div>
+        )}
+      </main>
+    </>
+  )
+}

--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -1,0 +1,96 @@
+import Link from 'next/link'
+import { Card as ShadcnCard, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import type { BlogPost } from '@/lib/strapi'
+
+export interface BlogCardProps {
+  post: BlogPost
+  className?: string
+}
+
+/**
+ * Format a date string for display
+ */
+function formatDate(dateString: string | null): string {
+  if (!dateString) return ''
+  const date = new Date(dateString)
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+const BlogCard = ({ post, className = '' }: BlogCardProps) => {
+  return (
+    <article className={cn('blog-card', className)}>
+      <Link
+        href={`/blog/${post.slug}`}
+        className="block no-underline text-inherit hover:no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 rounded-xl transition-all"
+        aria-label={`Read ${post.title}`}
+      >
+        <ShadcnCard className="h-full transition-all duration-200 hover:shadow-lg hover:scale-[1.02] border-gray-200">
+          <CardHeader className="pt-6 pb-2">
+            {/* Category and Reading Time */}
+            <div className="flex items-center gap-2 text-xs text-gray-500 mb-2">
+              {post.category && (
+                <>
+                  <span className="bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-medium">
+                    {post.category}
+                  </span>
+                  <span aria-hidden="true">·</span>
+                </>
+              )}
+              <span>{post.reading_time} min read</span>
+            </div>
+
+            <CardTitle className="blog-card__title">
+              <h3 className="text-xl font-semibold leading-tight tracking-tight text-gray-900 line-clamp-2">
+                {post.title}
+              </h3>
+            </CardTitle>
+          </CardHeader>
+
+          <CardContent className="blog-card__content pt-0">
+            <CardDescription>
+              <p className="blog-card__excerpt text-sm text-gray-600 line-clamp-3 mb-4">
+                {post.excerpt}
+              </p>
+            </CardDescription>
+
+            {/* Footer with date and author */}
+            <div className="flex items-center justify-between text-xs text-gray-500 pt-2 border-t border-gray-100">
+              <time dateTime={post.published_at || post.created_at}>
+                {formatDate(post.published_at || post.created_at)}
+              </time>
+              {post.author && (
+                <span className="font-medium">{post.author}</span>
+              )}
+            </div>
+
+            {/* Tags */}
+            {post.tags && post.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1 mt-3">
+                {post.tags.slice(0, 3).map((tag) => (
+                  <span
+                    key={tag}
+                    className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded"
+                  >
+                    {tag}
+                  </span>
+                ))}
+                {post.tags.length > 3 && (
+                  <span className="text-xs text-gray-400">
+                    +{post.tags.length - 3} more
+                  </span>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </ShadcnCard>
+      </Link>
+    </article>
+  )
+}
+
+export default BlogCard

--- a/app/components/BlogFilters.tsx
+++ b/app/components/BlogFilters.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+interface BlogFiltersProps {
+  categories: string[]
+  tags: string[]
+  selectedCategory: string | null
+  selectedTags: string[]
+  onCategoryChange: (category: string | null) => void
+  onTagChange: (tag: string) => void
+  onClearFilters: () => void
+}
+
+export default function BlogFilters({
+  categories,
+  tags,
+  selectedCategory,
+  selectedTags,
+  onCategoryChange,
+  onTagChange,
+  onClearFilters,
+}: BlogFiltersProps) {
+  const activeFilterCount =
+    (selectedCategory ? 1 : 0) + selectedTags.length
+
+  const hasActiveFilters = activeFilterCount > 0
+
+  const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value
+    onCategoryChange(value === '' ? null : value)
+  }
+
+  return (
+    <fieldset
+      role="group"
+      aria-label="Filter posts"
+      className="mb-8 p-4 bg-gray-50 rounded-lg border border-gray-200"
+    >
+      <div className="flex flex-wrap gap-6 items-start">
+        {/* Category Filter */}
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="category-filter"
+            className="text-sm font-medium text-gray-700"
+          >
+            Category
+          </label>
+          <select
+            id="category-filter"
+            value={selectedCategory || ''}
+            onChange={handleCategoryChange}
+            className="px-3 py-2 border border-gray-300 rounded-md bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">All Categories</option>
+            {categories.map((category) => (
+              <option key={category} value={category}>
+                {category}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Tag Filters */}
+        {tags.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-medium text-gray-700">Tags</span>
+            <div className="flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <label
+                  key={tag}
+                  className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm cursor-pointer transition-colors ${
+                    selectedTags.includes(tag)
+                      ? 'bg-blue-100 text-blue-800 border border-blue-300'
+                      : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-100'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    className="sr-only"
+                    checked={selectedTags.includes(tag)}
+                    onChange={() => onTagChange(tag)}
+                  />
+                  {tag}
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Active filter info and clear button */}
+      <div className="flex items-center justify-between mt-4">
+        {activeFilterCount > 0 && (
+          <span className="text-sm text-gray-600">
+            {activeFilterCount} {activeFilterCount === 1 ? 'filter' : 'filters'} active
+          </span>
+        )}
+
+        {hasActiveFilters && (
+          <button
+            onClick={onClearFilters}
+            className="text-sm text-blue-600 hover:text-blue-800 hover:underline"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+    </fieldset>
+  )
+}

--- a/app/components/BlogListClient.tsx
+++ b/app/components/BlogListClient.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { useMemo, useCallback } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import type { BlogPost } from '@/lib/strapi'
+import BlogCard from './BlogCard'
+import BlogFilters from './BlogFilters'
+import Pagination from './Pagination'
+
+interface BlogListClientProps {
+  posts: BlogPost[]
+  postsPerPage?: number
+}
+
+export default function BlogListClient({
+  posts,
+  postsPerPage = 10,
+}: BlogListClientProps) {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+
+  // Read filter state from URL
+  const selectedCategory = searchParams.get('category')
+  const selectedTags = useMemo(() => {
+    const tagsParam = searchParams.get('tags')
+    return tagsParam ? tagsParam.split(',') : []
+  }, [searchParams])
+  const currentPage = parseInt(searchParams.get('page') || '1', 10)
+
+  // Extract unique categories and tags from posts
+  const categories = useMemo(() => {
+    const cats = new Set<string>()
+    posts.forEach((post) => {
+      if (post.category) cats.add(post.category)
+    })
+    return Array.from(cats).sort()
+  }, [posts])
+
+  const tags = useMemo(() => {
+    const allTags = new Set<string>()
+    posts.forEach((post) => {
+      post.tags?.forEach((tag) => allTags.add(tag))
+    })
+    return Array.from(allTags).sort()
+  }, [posts])
+
+  // Filter posts based on selected filters
+  const filteredPosts = useMemo(() => {
+    return posts.filter((post) => {
+      // Category filter
+      if (selectedCategory && post.category !== selectedCategory) {
+        return false
+      }
+
+      // Tag filter (OR logic - post must have at least one selected tag)
+      if (selectedTags.length > 0) {
+        const postTags = post.tags || []
+        const hasMatchingTag = selectedTags.some((tag) => postTags.includes(tag))
+        if (!hasMatchingTag) {
+          return false
+        }
+      }
+
+      return true
+    })
+  }, [posts, selectedCategory, selectedTags])
+
+  // Pagination
+  const totalPages = Math.ceil(filteredPosts.length / postsPerPage)
+  const validPage = Math.min(Math.max(1, currentPage), Math.max(1, totalPages))
+  const startIndex = (validPage - 1) * postsPerPage
+  const paginatedPosts = filteredPosts.slice(startIndex, startIndex + postsPerPage)
+
+  // Update URL with new params
+  const updateUrl = useCallback(
+    (params: Record<string, string | null>) => {
+      const newParams = new URLSearchParams(searchParams.toString())
+
+      Object.entries(params).forEach(([key, value]) => {
+        if (value === null || value === '') {
+          newParams.delete(key)
+        } else {
+          newParams.set(key, value)
+        }
+      })
+
+      const queryString = newParams.toString()
+      router.push(queryString ? `?${queryString}` : '', { scroll: false })
+    },
+    [searchParams, router]
+  )
+
+  // Handler for category change
+  const handleCategoryChange = useCallback(
+    (category: string | null) => {
+      updateUrl({ category, page: null }) // Reset page on filter change
+    },
+    [updateUrl]
+  )
+
+  // Handler for tag change (toggle)
+  const handleTagChange = useCallback(
+    (tag: string) => {
+      const newTags = selectedTags.includes(tag)
+        ? selectedTags.filter((t) => t !== tag)
+        : [...selectedTags, tag]
+
+      updateUrl({
+        tags: newTags.length > 0 ? newTags.join(',') : null,
+        page: null, // Reset page on filter change
+      })
+    },
+    [selectedTags, updateUrl]
+  )
+
+  // Handler for clearing all filters
+  const handleClearFilters = useCallback(() => {
+    updateUrl({ category: null, tags: null, page: null })
+  }, [updateUrl])
+
+  // Handler for page change
+  const handlePageChange = useCallback(
+    (page: number) => {
+      updateUrl({ page: page.toString() })
+    },
+    [updateUrl]
+  )
+
+  return (
+    <div className="blog-list">
+      {/* Filters */}
+      <BlogFilters
+        categories={categories}
+        tags={tags}
+        selectedCategory={selectedCategory}
+        selectedTags={selectedTags}
+        onCategoryChange={handleCategoryChange}
+        onTagChange={handleTagChange}
+        onClearFilters={handleClearFilters}
+      />
+
+      {/* Results count */}
+      <p className="text-sm text-gray-600 mb-4">
+        Showing {filteredPosts.length} {filteredPosts.length === 1 ? 'post' : 'posts'}
+      </p>
+
+      {/* Posts grid or empty state */}
+      {paginatedPosts.length > 0 ? (
+        <div className="blog__grid grid gap-6 md:grid-cols-2">
+          {paginatedPosts.map((post) => (
+            <BlogCard key={post.id || post.slug} post={post} />
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-12 bg-gray-50 rounded-lg border border-gray-200">
+          <p className="text-gray-600 mb-4">No posts found matching your filters.</p>
+          <button
+            onClick={handleClearFilters}
+            className="text-blue-600 hover:text-blue-800 hover:underline"
+          >
+            Clear filters
+          </button>
+        </div>
+      )}
+
+      {/* Pagination */}
+      <Pagination
+        currentPage={validPage}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
+      />
+    </div>
+  )
+}

--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+export default function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) {
+  // Don't render if only one page
+  if (totalPages <= 1) {
+    return null
+  }
+
+  const handlePrevious = () => {
+    if (currentPage > 1) {
+      onPageChange(currentPage - 1)
+    }
+  }
+
+  const handleNext = () => {
+    if (currentPage < totalPages) {
+      onPageChange(currentPage + 1)
+    }
+  }
+
+  const isPreviousDisabled = currentPage <= 1
+  const isNextDisabled = currentPage >= totalPages
+
+  return (
+    <nav aria-label="Pagination" className="flex items-center justify-center gap-4 mt-8">
+      <button
+        onClick={handlePrevious}
+        disabled={isPreviousDisabled}
+        aria-label="Previous page"
+        className={`px-4 py-2 rounded-md border ${
+          isPreviousDisabled
+            ? 'bg-gray-100 text-gray-400 cursor-not-allowed border-gray-200'
+            : 'bg-white text-gray-700 hover:bg-gray-50 border-gray-300'
+        }`}
+      >
+        Previous
+      </button>
+
+      <span aria-current="page" className="text-gray-600">
+        Page {currentPage} of {totalPages}
+      </span>
+
+      <button
+        onClick={handleNext}
+        disabled={isNextDisabled}
+        aria-label="Next page"
+        className={`px-4 py-2 rounded-md border ${
+          isNextDisabled
+            ? 'bg-gray-100 text-gray-400 cursor-not-allowed border-gray-200'
+            : 'bg-white text-gray-700 hover:bg-gray-50 border-gray-300'
+        }`}
+      >
+        Next
+      </button>
+    </nav>
+  )
+}

--- a/app/components/StructuredData.tsx
+++ b/app/components/StructuredData.tsx
@@ -3,6 +3,7 @@ import type { Poem } from '@/data/poetry'
 import type { Essay } from '@/data/essays'
 import type { Story } from '@/data/fiction'
 import type { Paper } from '@/data/papers'
+import type { BlogPost } from '@/lib/strapi'
 
 export interface PersonData {
   name: string
@@ -15,8 +16,8 @@ export interface PersonData {
 }
 
 export interface StructuredDataProps {
-  type: 'person' | 'poem' | 'essay' | 'story' | 'paper'
-  data?: PersonData | Poem | Essay | Story | Paper
+  type: 'person' | 'poem' | 'essay' | 'story' | 'paper' | 'blog'
+  data?: PersonData | Poem | Essay | Story | Paper | BlogPost
 }
 
 const StructuredData = ({ type, data }: StructuredDataProps) => {
@@ -131,6 +132,27 @@ const StructuredData = ({ type, data }: StructuredDataProps) => {
       keywords: paper.tags.join(', '),
       inLanguage: 'en-US',
       version: paper.version,
+    }
+  } else if (type === 'blog' && data) {
+    // Schema.org BlogPosting for blog posts
+    const post = data as BlogPost
+    jsonLd = {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: post.title,
+      articleBody: post.content,
+      author: {
+        '@type': 'Person',
+        name: post.author || 'Karsten Wade',
+        url: 'https://karstenwade.com',
+      },
+      datePublished: post.published_at,
+      dateModified: post.updated_at,
+      url: `https://karstenwade.com/blog/${post.slug}`,
+      keywords: post.tags?.join(', '),
+      inLanguage: 'en-US',
+      abstract: post.excerpt,
+      articleSection: post.category,
     }
   }
 

--- a/app/components/__tests__/BlogFilters.test.tsx
+++ b/app/components/__tests__/BlogFilters.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * BlogFilters Component Tests
+ * Story 16.5c: Add blog filtering and pagination
+ *
+ * RED PHASE: These tests define the expected behavior.
+ * The BlogFilters component does not exist yet.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import BlogFilters from '../BlogFilters'
+
+describe('BlogFilters Component', () => {
+  const defaultProps = {
+    categories: ['Technology', 'Open Source', 'Community'],
+    tags: ['AI', 'Linux', 'DevOps', 'Culture'],
+    selectedCategory: null as string | null,
+    selectedTags: [] as string[],
+    onCategoryChange: vi.fn(),
+    onTagChange: vi.fn(),
+    onClearFilters: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('category filtering', () => {
+    it('renders category dropdown', () => {
+      render(<BlogFilters {...defaultProps} />)
+      expect(screen.getByLabelText(/category/i)).toBeInTheDocument()
+    })
+
+    it('renders all categories as options', () => {
+      render(<BlogFilters {...defaultProps} />)
+      const select = screen.getByLabelText(/category/i)
+      expect(select).toBeInTheDocument()
+
+      // Check for "All Categories" option
+      expect(screen.getByRole('option', { name: /all categories/i })).toBeInTheDocument()
+
+      // Check for each category
+      defaultProps.categories.forEach(category => {
+        expect(screen.getByRole('option', { name: category })).toBeInTheDocument()
+      })
+    })
+
+    it('shows selected category', () => {
+      render(<BlogFilters {...defaultProps} selectedCategory="Technology" />)
+      const select = screen.getByLabelText(/category/i) as HTMLSelectElement
+      expect(select.value).toBe('Technology')
+    })
+
+    it('calls onCategoryChange when category is selected', () => {
+      const onCategoryChange = vi.fn()
+      render(<BlogFilters {...defaultProps} onCategoryChange={onCategoryChange} />)
+
+      fireEvent.change(screen.getByLabelText(/category/i), {
+        target: { value: 'Open Source' },
+      })
+
+      expect(onCategoryChange).toHaveBeenCalledWith('Open Source')
+    })
+
+    it('calls onCategoryChange with null when "All Categories" is selected', () => {
+      const onCategoryChange = vi.fn()
+      render(
+        <BlogFilters
+          {...defaultProps}
+          selectedCategory="Technology"
+          onCategoryChange={onCategoryChange}
+        />
+      )
+
+      fireEvent.change(screen.getByLabelText(/category/i), {
+        target: { value: '' },
+      })
+
+      expect(onCategoryChange).toHaveBeenCalledWith(null)
+    })
+  })
+
+  describe('tag filtering', () => {
+    it('renders tag filter section', () => {
+      render(<BlogFilters {...defaultProps} />)
+      expect(screen.getByText(/tags/i)).toBeInTheDocument()
+    })
+
+    it('renders all tags as checkable items', () => {
+      render(<BlogFilters {...defaultProps} />)
+
+      defaultProps.tags.forEach(tag => {
+        expect(screen.getByLabelText(tag)).toBeInTheDocument()
+      })
+    })
+
+    it('shows selected tags as checked', () => {
+      render(<BlogFilters {...defaultProps} selectedTags={['AI', 'Linux']} />)
+
+      expect(screen.getByLabelText('AI')).toBeChecked()
+      expect(screen.getByLabelText('Linux')).toBeChecked()
+      expect(screen.getByLabelText('DevOps')).not.toBeChecked()
+    })
+
+    it('calls onTagChange when tag is clicked', () => {
+      const onTagChange = vi.fn()
+      render(<BlogFilters {...defaultProps} onTagChange={onTagChange} />)
+
+      fireEvent.click(screen.getByLabelText('AI'))
+      expect(onTagChange).toHaveBeenCalledWith('AI')
+    })
+
+    it('calls onTagChange when selected tag is unchecked', () => {
+      const onTagChange = vi.fn()
+      render(
+        <BlogFilters
+          {...defaultProps}
+          selectedTags={['AI']}
+          onTagChange={onTagChange}
+        />
+      )
+
+      fireEvent.click(screen.getByLabelText('AI'))
+      expect(onTagChange).toHaveBeenCalledWith('AI')
+    })
+  })
+
+  describe('clear filters', () => {
+    it('renders clear filters button when filters are active', () => {
+      render(<BlogFilters {...defaultProps} selectedCategory="Technology" />)
+      expect(screen.getByRole('button', { name: /clear filters/i })).toBeInTheDocument()
+    })
+
+    it('renders clear filters button when tags are selected', () => {
+      render(<BlogFilters {...defaultProps} selectedTags={['AI']} />)
+      expect(screen.getByRole('button', { name: /clear filters/i })).toBeInTheDocument()
+    })
+
+    it('does not render clear filters button when no filters are active', () => {
+      render(<BlogFilters {...defaultProps} />)
+      expect(screen.queryByRole('button', { name: /clear filters/i })).not.toBeInTheDocument()
+    })
+
+    it('calls onClearFilters when clear button is clicked', () => {
+      const onClearFilters = vi.fn()
+      render(
+        <BlogFilters
+          {...defaultProps}
+          selectedCategory="Technology"
+          onClearFilters={onClearFilters}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /clear filters/i }))
+      expect(onClearFilters).toHaveBeenCalled()
+    })
+  })
+
+  describe('active filter count', () => {
+    it('shows count of active filters', () => {
+      render(
+        <BlogFilters
+          {...defaultProps}
+          selectedCategory="Technology"
+          selectedTags={['AI', 'Linux']}
+        />
+      )
+
+      // Should show "3 filters active" (1 category + 2 tags)
+      expect(screen.getByText(/3 filters? active/i)).toBeInTheDocument()
+    })
+
+    it('does not show count when no filters active', () => {
+      render(<BlogFilters {...defaultProps} />)
+      expect(screen.queryByText(/filters? active/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('empty states', () => {
+    it('handles empty categories gracefully', () => {
+      render(<BlogFilters {...defaultProps} categories={[]} />)
+      expect(screen.getByLabelText(/category/i)).toBeInTheDocument()
+      // Should still have "All Categories" option
+      expect(screen.getByRole('option', { name: /all categories/i })).toBeInTheDocument()
+    })
+
+    it('handles empty tags gracefully', () => {
+      render(<BlogFilters {...defaultProps} tags={[]} />)
+      // Should not show tags section or show "No tags available"
+      expect(screen.queryByText(/tags/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has proper form labeling', () => {
+      render(<BlogFilters {...defaultProps} />)
+      expect(screen.getByRole('group', { name: /filter posts/i })).toBeInTheDocument()
+    })
+
+    it('tags have proper checkbox role', () => {
+      render(<BlogFilters {...defaultProps} />)
+      const checkboxes = screen.getAllByRole('checkbox')
+      expect(checkboxes.length).toBe(defaultProps.tags.length)
+    })
+  })
+})

--- a/app/components/__tests__/BlogListClient.test.tsx
+++ b/app/components/__tests__/BlogListClient.test.tsx
@@ -1,0 +1,397 @@
+/**
+ * BlogListClient Component Tests
+ * Story 16.5c: Add blog filtering and pagination
+ *
+ * RED PHASE: These tests define the expected behavior.
+ * The BlogListClient component does not exist yet.
+ *
+ * This is the client-side component that handles:
+ * - Filtering posts by category and tags
+ * - Pagination
+ * - URL state management
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import BlogListClient from '../BlogListClient'
+import type { BlogPost } from '@/lib/strapi'
+
+// Mock Next.js navigation with stateful URL tracking
+let currentSearchParams = new URLSearchParams()
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: vi.fn(() => currentSearchParams),
+  useRouter: vi.fn(() => ({
+    push: vi.fn((url: string) => {
+      // Extract query string and update currentSearchParams
+      const queryString = url.startsWith('?') ? url.slice(1) : url.includes('?') ? url.split('?')[1] : ''
+      currentSearchParams = new URLSearchParams(queryString)
+    }),
+  })),
+}))
+
+const mockPosts: BlogPost[] = [
+  {
+    id: '1',
+    strapi_id: 1,
+    title: 'Post about AI',
+    slug: 'post-about-ai',
+    excerpt: 'AI excerpt',
+    content: 'AI content',
+    reading_time: 5,
+    published_at: '2024-01-15',
+    created_at: '2024-01-15',
+    updated_at: '2024-01-15',
+    author: 'Karsten',
+    category: 'Technology',
+    tags: ['AI', 'ML'],
+  },
+  {
+    id: '2',
+    strapi_id: 2,
+    title: 'Post about Open Source',
+    slug: 'post-about-open-source',
+    excerpt: 'OS excerpt',
+    content: 'OS content',
+    reading_time: 8,
+    published_at: '2024-01-10',
+    created_at: '2024-01-10',
+    updated_at: '2024-01-10',
+    author: 'Karsten',
+    category: 'Open Source',
+    tags: ['Linux', 'Community'],
+  },
+  {
+    id: '3',
+    strapi_id: 3,
+    title: 'Post about Community',
+    slug: 'post-about-community',
+    excerpt: 'Community excerpt',
+    content: 'Community content',
+    reading_time: 6,
+    published_at: '2024-01-05',
+    created_at: '2024-01-05',
+    updated_at: '2024-01-05',
+    author: 'Karsten',
+    category: 'Community',
+    tags: ['Community', 'Culture'],
+  },
+  {
+    id: '4',
+    strapi_id: 4,
+    title: 'Another Tech Post',
+    slug: 'another-tech-post',
+    excerpt: 'Tech excerpt',
+    content: 'Tech content',
+    reading_time: 4,
+    published_at: '2024-01-01',
+    created_at: '2024-01-01',
+    updated_at: '2024-01-01',
+    author: 'Karsten',
+    category: 'Technology',
+    tags: ['DevOps'],
+  },
+]
+
+describe('BlogListClient Component', () => {
+  const mockRouterPush = vi.fn()
+
+  // Helper to set URL params for a test
+  const setSearchParams = (params: string) => {
+    currentSearchParams = new URLSearchParams(params)
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset URL state
+    currentSearchParams = new URLSearchParams()
+
+    // Set up router mock that updates currentSearchParams
+    mockRouterPush.mockImplementation((url: string) => {
+      const queryString = url.startsWith('?') ? url.slice(1) : url.includes('?') ? url.split('?')[1] : ''
+      currentSearchParams = new URLSearchParams(queryString)
+    })
+
+    ;(useRouter as ReturnType<typeof vi.fn>).mockReturnValue({
+      push: mockRouterPush,
+    })
+    ;(useSearchParams as ReturnType<typeof vi.fn>).mockImplementation(
+      () => currentSearchParams
+    )
+  })
+
+  describe('rendering', () => {
+    it('renders all posts when no filters applied', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      mockPosts.forEach(post => {
+        expect(screen.getByText(post.title)).toBeInTheDocument()
+      })
+    })
+
+    it('renders BlogFilters component', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+      expect(screen.getByLabelText(/category/i)).toBeInTheDocument()
+    })
+
+    it('extracts unique categories from posts', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      expect(screen.getByRole('option', { name: 'Technology' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Open Source' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'Community' })).toBeInTheDocument()
+    })
+
+    it('extracts unique tags from posts', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      // All unique tags should be present
+      expect(screen.getByLabelText('AI')).toBeInTheDocument()
+      expect(screen.getByLabelText('ML')).toBeInTheDocument()
+      expect(screen.getByLabelText('Linux')).toBeInTheDocument()
+      expect(screen.getByLabelText('Community')).toBeInTheDocument()
+      expect(screen.getByLabelText('Culture')).toBeInTheDocument()
+      expect(screen.getByLabelText('DevOps')).toBeInTheDocument()
+    })
+  })
+
+  describe('category filtering', () => {
+    it('filters posts by selected category', () => {
+      // Set URL params before rendering to test filtering
+      setSearchParams('category=Technology')
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      // Should show only Technology posts
+      expect(screen.getByText('Post about AI')).toBeInTheDocument()
+      expect(screen.getByText('Another Tech Post')).toBeInTheDocument()
+      expect(screen.queryByText('Post about Open Source')).not.toBeInTheDocument()
+      expect(screen.queryByText('Post about Community')).not.toBeInTheDocument()
+    })
+
+    it('shows all posts when category filter is cleared', () => {
+      // Start with no filters
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      // All posts should be visible
+      mockPosts.forEach(post => {
+        expect(screen.getByText(post.title)).toBeInTheDocument()
+      })
+    })
+
+    it('updates URL when category is changed', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      fireEvent.change(screen.getByLabelText(/category/i), {
+        target: { value: 'Technology' },
+      })
+
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        expect.stringContaining('category=Technology'),
+        { scroll: false }
+      )
+    })
+  })
+
+  describe('tag filtering', () => {
+    it('filters posts by selected tag', () => {
+      // Set URL params to test filtering with tag
+      setSearchParams('tags=AI')
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      // Should show only posts with AI tag
+      expect(screen.getByText('Post about AI')).toBeInTheDocument()
+      expect(screen.queryByText('Post about Open Source')).not.toBeInTheDocument()
+    })
+
+    it('filters posts by multiple tags (OR logic)', () => {
+      // Set URL params with multiple tags
+      setSearchParams('tags=AI,Linux')
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      // Should show posts with AI OR Linux
+      expect(screen.getByText('Post about AI')).toBeInTheDocument()
+      expect(screen.getByText('Post about Open Source')).toBeInTheDocument()
+      expect(screen.queryByText('Another Tech Post')).not.toBeInTheDocument()
+    })
+
+    it('combines category and tag filters (AND logic)', () => {
+      // Set URL params with category AND tag
+      setSearchParams('category=Community&tags=Culture')
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      // Should show only Community category posts with Culture tag
+      expect(screen.getByText('Post about Community')).toBeInTheDocument()
+      expect(screen.queryByText('Post about AI')).not.toBeInTheDocument()
+    })
+
+    it('updates URL when tag is clicked', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      fireEvent.click(screen.getByLabelText('AI'))
+
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        expect.stringContaining('tags=AI'),
+        { scroll: false }
+      )
+    })
+  })
+
+  describe('pagination', () => {
+    it('paginates posts', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={2} />)
+
+      // Should show first 2 posts only
+      expect(screen.getByText('Post about AI')).toBeInTheDocument()
+      expect(screen.getByText('Post about Open Source')).toBeInTheDocument()
+      expect(screen.queryByText('Post about Community')).not.toBeInTheDocument()
+    })
+
+    it('renders pagination controls when posts exceed page size', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={2} />)
+
+      expect(screen.getByRole('navigation', { name: /pagination/i })).toBeInTheDocument()
+      expect(screen.getByText('Page 1 of 2')).toBeInTheDocument()
+    })
+
+    it('does not render pagination when all posts fit on one page', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      expect(screen.queryByRole('navigation', { name: /pagination/i })).not.toBeInTheDocument()
+    })
+
+    it('shows page 2 posts when page=2 in URL', () => {
+      setSearchParams('page=2')
+      render(<BlogListClient posts={mockPosts} postsPerPage={2} />)
+
+      // Should show page 2 posts
+      expect(screen.queryByText('Post about AI')).not.toBeInTheDocument()
+      expect(screen.getByText('Post about Community')).toBeInTheDocument()
+      expect(screen.getByText('Another Tech Post')).toBeInTheDocument()
+    })
+
+    it('updates URL when next page button is clicked', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={2} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /next/i }))
+
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        expect.stringContaining('page=2'),
+        { scroll: false }
+      )
+    })
+
+    it('resets page param when filters change', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={2} />)
+
+      // Change category filter
+      fireEvent.change(screen.getByLabelText(/category/i), {
+        target: { value: 'Technology' },
+      })
+
+      // Should not include page param (reset to page 1)
+      expect(mockRouterPush).toHaveBeenCalled()
+      const call = mockRouterPush.mock.calls[0][0]
+      expect(call).not.toContain('page=')
+    })
+  })
+
+  describe('URL state management', () => {
+    it('reads initial category filter from URL params', () => {
+      setSearchParams('category=Technology')
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      // Should filter by category from URL
+      expect(screen.getByText('Post about AI')).toBeInTheDocument()
+      expect(screen.queryByText('Post about Open Source')).not.toBeInTheDocument()
+    })
+
+    it('reads tag filters from URL params', () => {
+      setSearchParams('tags=AI,Linux')
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      // Should filter by tags from URL
+      expect(screen.getByText('Post about AI')).toBeInTheDocument()
+      expect(screen.getByText('Post about Open Source')).toBeInTheDocument()
+    })
+
+    it('reads page number from URL params', () => {
+      setSearchParams('page=2')
+      render(<BlogListClient posts={mockPosts} postsPerPage={2} />)
+
+      // Should show page 2
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument()
+    })
+
+    it('updates URL when category filter changes', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      fireEvent.change(screen.getByLabelText(/category/i), {
+        target: { value: 'Technology' },
+      })
+
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        expect.stringContaining('category=Technology'),
+        { scroll: false }
+      )
+    })
+
+    it('updates URL when tag filter changes', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      fireEvent.click(screen.getByLabelText('AI'))
+
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        expect.stringContaining('tags=AI'),
+        { scroll: false }
+      )
+    })
+
+    it('updates URL when page changes', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={2} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /next/i }))
+
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        expect.stringContaining('page=2'),
+        { scroll: false }
+      )
+    })
+  })
+
+  describe('results count', () => {
+    it('shows total results count', () => {
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      expect(screen.getByText(/showing 4 posts/i)).toBeInTheDocument()
+    })
+
+    it('shows filtered results count when category is set', () => {
+      setSearchParams('category=Technology')
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      expect(screen.getByText(/showing 2 posts/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('empty state', () => {
+    it('shows empty state when no posts match filters', () => {
+      // Technology category with Culture tag = no matches
+      setSearchParams('category=Technology&tags=Culture')
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      expect(screen.getByText(/no posts found/i)).toBeInTheDocument()
+    })
+
+    it('shows clear filters button in empty state', () => {
+      // Technology category with Culture tag = no matches
+      setSearchParams('category=Technology&tags=Culture')
+      render(<BlogListClient posts={mockPosts} postsPerPage={10} />)
+
+      // There are two clear filters buttons - one in filters, one in empty state
+      // Verify both exist
+      const clearButtons = screen.getAllByRole('button', { name: /clear filters/i })
+      expect(clearButtons.length).toBe(2)
+    })
+  })
+})

--- a/app/components/__tests__/Pagination.test.tsx
+++ b/app/components/__tests__/Pagination.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Pagination Component Tests
+ * Story 16.5c: Add blog filtering and pagination
+ *
+ * RED PHASE: These tests define the expected behavior.
+ * The Pagination component does not exist yet.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import Pagination from '../Pagination'
+
+describe('Pagination Component', () => {
+  const defaultProps = {
+    currentPage: 1,
+    totalPages: 5,
+    onPageChange: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('rendering', () => {
+    it('renders current page indicator', () => {
+      render(<Pagination {...defaultProps} />)
+      expect(screen.getByText('Page 1 of 5')).toBeInTheDocument()
+    })
+
+    it('renders previous button', () => {
+      render(<Pagination {...defaultProps} />)
+      expect(screen.getByRole('button', { name: /previous/i })).toBeInTheDocument()
+    })
+
+    it('renders next button', () => {
+      render(<Pagination {...defaultProps} />)
+      expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument()
+    })
+
+    it('disables previous button on first page', () => {
+      render(<Pagination {...defaultProps} currentPage={1} />)
+      expect(screen.getByRole('button', { name: /previous/i })).toBeDisabled()
+    })
+
+    it('disables next button on last page', () => {
+      render(<Pagination {...defaultProps} currentPage={5} />)
+      expect(screen.getByRole('button', { name: /next/i })).toBeDisabled()
+    })
+
+    it('enables both buttons on middle pages', () => {
+      render(<Pagination {...defaultProps} currentPage={3} />)
+      expect(screen.getByRole('button', { name: /previous/i })).not.toBeDisabled()
+      expect(screen.getByRole('button', { name: /next/i })).not.toBeDisabled()
+    })
+
+    it('does not render when totalPages is 1', () => {
+      const { container } = render(<Pagination {...defaultProps} totalPages={1} />)
+      expect(container.firstChild).toBeNull()
+    })
+  })
+
+  describe('navigation', () => {
+    it('calls onPageChange with previous page when clicking previous', () => {
+      const onPageChange = vi.fn()
+      render(<Pagination {...defaultProps} currentPage={3} onPageChange={onPageChange} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /previous/i }))
+      expect(onPageChange).toHaveBeenCalledWith(2)
+    })
+
+    it('calls onPageChange with next page when clicking next', () => {
+      const onPageChange = vi.fn()
+      render(<Pagination {...defaultProps} currentPage={3} onPageChange={onPageChange} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /next/i }))
+      expect(onPageChange).toHaveBeenCalledWith(4)
+    })
+
+    it('does not call onPageChange when clicking disabled previous', () => {
+      const onPageChange = vi.fn()
+      render(<Pagination {...defaultProps} currentPage={1} onPageChange={onPageChange} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /previous/i }))
+      expect(onPageChange).not.toHaveBeenCalled()
+    })
+
+    it('does not call onPageChange when clicking disabled next', () => {
+      const onPageChange = vi.fn()
+      render(<Pagination {...defaultProps} currentPage={5} onPageChange={onPageChange} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /next/i }))
+      expect(onPageChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has proper aria-label on pagination nav', () => {
+      render(<Pagination {...defaultProps} />)
+      expect(screen.getByRole('navigation', { name: /pagination/i })).toBeInTheDocument()
+    })
+
+    it('has aria-current on current page indicator', () => {
+      render(<Pagination {...defaultProps} currentPage={3} />)
+      expect(screen.getByText('Page 3 of 5')).toHaveAttribute('aria-current', 'page')
+    })
+  })
+})

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -1,0 +1,439 @@
+/**
+ * Strapi/ZeroDB Client for Next.js Frontend
+ *
+ * This client fetches blog content from ZeroDB (synced from Strapi).
+ * Architecture:
+ * - Strapi manages content via SQLite (admin interface)
+ * - Lifecycle hooks sync content to ZeroDB
+ * - This client reads from ZeroDB for production performance
+ */
+
+// Blog Post type matching ZeroDB schema
+export interface BlogPost {
+  id: string
+  strapi_id: number
+  title: string
+  slug: string
+  excerpt: string
+  content: string
+  reading_time: number
+  published_at: string | null
+  created_at: string
+  updated_at: string
+  author: string | null
+  category: string | null
+  tags: string[]
+}
+
+// Tutorial type matching ZeroDB schema
+export interface Tutorial {
+  id: string
+  strapi_id: number
+  title: string
+  slug: string
+  description: string
+  content: string
+  difficulty: 'beginner' | 'intermediate' | 'advanced'
+  duration: number
+  published_at: string | null
+  created_at: string
+  updated_at: string
+  author: string | null
+  category: string | null
+  tags: string[]
+}
+
+// Event type matching ZeroDB schema
+export interface Event {
+  id: string
+  strapi_id: number
+  title: string
+  slug: string
+  description: string
+  short_description: string
+  event_type: string
+  start_date: string
+  end_date: string | null
+  timezone: string
+  is_virtual: boolean
+  location: string
+  venue_name: string
+  city: string
+  country: string
+  virtual_url: string
+  registration_url: string
+  max_attendees: number | null
+  current_attendees: number
+  is_free: boolean
+  price: number | null
+  status: string
+  published_at: string | null
+  created_at: string
+  updated_at: string
+  organizer: string | null
+  category: string | null
+}
+
+interface ZeroDBConfig {
+  apiUrl: string
+  projectId: string
+  username: string
+  password: string
+}
+
+interface TokenResponse {
+  access_token: string
+  token_type: string
+  expires_in: number
+}
+
+interface QueryResult<T> {
+  rows: T[]
+  total_count: number
+}
+
+class StrapiClient {
+  private config: ZeroDBConfig
+  private accessToken: string | null = null
+  private tokenExpiry: Date | null = null
+
+  constructor() {
+    this.config = {
+      apiUrl: process.env.ZERODB_API_URL || 'https://api.ainative.studio',
+      projectId: process.env.ZERODB_PROJECT_ID || '',
+      username: process.env.ZERODB_USERNAME || '',
+      password: process.env.ZERODB_PASSWORD || '',
+    }
+  }
+
+  /**
+   * Check if the client is properly configured
+   */
+  isConfigured(): boolean {
+    return !!(
+      this.config.projectId &&
+      this.config.username &&
+      this.config.password
+    )
+  }
+
+  /**
+   * Authenticate with ZeroDB and get access token
+   */
+  private async authenticate(): Promise<string> {
+    if (this.accessToken && this.tokenExpiry && this.tokenExpiry > new Date()) {
+      return this.accessToken
+    }
+
+    const response = await fetch(`${this.config.apiUrl}/v1/public/auth/login-json`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        username: this.config.username,
+        password: this.config.password,
+      }),
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(`ZeroDB authentication failed: ${error}`)
+    }
+
+    const data: TokenResponse = await response.json()
+    this.accessToken = data.access_token
+    this.tokenExpiry = new Date(Date.now() + 25 * 60 * 1000) // 25 minutes
+
+    return this.accessToken
+  }
+
+  /**
+   * Make authenticated request to ZeroDB API
+   */
+  private async request<T>(
+    endpoint: string,
+    method: 'GET' | 'POST' = 'GET',
+    body?: unknown
+  ): Promise<T> {
+    const token = await this.authenticate()
+
+    const response = await fetch(`${this.config.apiUrl}${endpoint}`, {
+      method,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      // Cache for 60 seconds in production, no cache in dev
+      next: { revalidate: process.env.NODE_ENV === 'production' ? 60 : 0 },
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(`ZeroDB API error: ${response.status} - ${error}`)
+    }
+
+    return response.json()
+  }
+
+  // ==========================================
+  // Blog Post Operations
+  // ==========================================
+
+  /**
+   * Get all published blog posts
+   */
+  async getBlogPosts(options?: {
+    limit?: number
+    offset?: number
+    category?: string
+    tag?: string
+  }): Promise<{ posts: BlogPost[]; total: number }> {
+    if (!this.isConfigured()) {
+      console.warn('[Strapi] Client not configured, returning empty results')
+      return { posts: [], total: 0 }
+    }
+
+    const filters: Record<string, unknown> = {
+      published_at: { $ne: null },
+    }
+
+    if (options?.category) {
+      filters.category = options.category
+    }
+
+    if (options?.tag) {
+      filters.tags = { $contains: options.tag }
+    }
+
+    try {
+      const result = await this.request<QueryResult<BlogPost>>(
+        `/v1/projects/${this.config.projectId}/tables/strapi_blog_posts/rows/query`,
+        'POST',
+        {
+          filter: filters,
+          limit: options?.limit || 20,
+          offset: options?.offset || 0,
+          sort: { published_at: -1 },
+        }
+      )
+
+      return {
+        posts: result.rows,
+        total: result.total_count,
+      }
+    } catch (error) {
+      console.error('[Strapi] Failed to fetch blog posts:', error)
+      return { posts: [], total: 0 }
+    }
+  }
+
+  /**
+   * Get a single blog post by slug
+   */
+  async getBlogPostBySlug(slug: string): Promise<BlogPost | null> {
+    if (!this.isConfigured()) {
+      console.warn('[Strapi] Client not configured')
+      return null
+    }
+
+    try {
+      const result = await this.request<QueryResult<BlogPost>>(
+        `/v1/projects/${this.config.projectId}/tables/strapi_blog_posts/rows/query`,
+        'POST',
+        {
+          filter: { slug, published_at: { $ne: null } },
+          limit: 1,
+        }
+      )
+
+      return result.rows[0] || null
+    } catch (error) {
+      console.error('[Strapi] Failed to fetch blog post:', error)
+      return null
+    }
+  }
+
+  /**
+   * Get all unique categories from blog posts
+   */
+  async getBlogCategories(): Promise<string[]> {
+    const { posts } = await this.getBlogPosts({ limit: 100 })
+    const categories = new Set<string>()
+    posts.forEach(post => {
+      if (post.category) categories.add(post.category)
+    })
+    return Array.from(categories).sort()
+  }
+
+  /**
+   * Get all unique tags from blog posts
+   */
+  async getBlogTags(): Promise<string[]> {
+    const { posts } = await this.getBlogPosts({ limit: 100 })
+    const tags = new Set<string>()
+    posts.forEach(post => {
+      post.tags?.forEach(tag => tags.add(tag))
+    })
+    return Array.from(tags).sort()
+  }
+
+  // ==========================================
+  // Tutorial Operations
+  // ==========================================
+
+  /**
+   * Get all published tutorials
+   */
+  async getTutorials(options?: {
+    limit?: number
+    offset?: number
+    difficulty?: string
+    category?: string
+  }): Promise<{ tutorials: Tutorial[]; total: number }> {
+    if (!this.isConfigured()) {
+      return { tutorials: [], total: 0 }
+    }
+
+    const filters: Record<string, unknown> = {
+      published_at: { $ne: null },
+    }
+
+    if (options?.difficulty) {
+      filters.difficulty = options.difficulty
+    }
+
+    if (options?.category) {
+      filters.category = options.category
+    }
+
+    try {
+      const result = await this.request<QueryResult<Tutorial>>(
+        `/v1/projects/${this.config.projectId}/tables/strapi_tutorials/rows/query`,
+        'POST',
+        {
+          filter: filters,
+          limit: options?.limit || 20,
+          offset: options?.offset || 0,
+          sort: { published_at: -1 },
+        }
+      )
+
+      return {
+        tutorials: result.rows,
+        total: result.total_count,
+      }
+    } catch (error) {
+      console.error('[Strapi] Failed to fetch tutorials:', error)
+      return { tutorials: [], total: 0 }
+    }
+  }
+
+  /**
+   * Get a single tutorial by slug
+   */
+  async getTutorialBySlug(slug: string): Promise<Tutorial | null> {
+    if (!this.isConfigured()) {
+      return null
+    }
+
+    try {
+      const result = await this.request<QueryResult<Tutorial>>(
+        `/v1/projects/${this.config.projectId}/tables/strapi_tutorials/rows/query`,
+        'POST',
+        {
+          filter: { slug, published_at: { $ne: null } },
+          limit: 1,
+        }
+      )
+
+      return result.rows[0] || null
+    } catch (error) {
+      console.error('[Strapi] Failed to fetch tutorial:', error)
+      return null
+    }
+  }
+
+  // ==========================================
+  // Event Operations
+  // ==========================================
+
+  /**
+   * Get upcoming events
+   */
+  async getEvents(options?: {
+    limit?: number
+    offset?: number
+    status?: string
+    isVirtual?: boolean
+  }): Promise<{ events: Event[]; total: number }> {
+    if (!this.isConfigured()) {
+      return { events: [], total: 0 }
+    }
+
+    const filters: Record<string, unknown> = {
+      published_at: { $ne: null },
+    }
+
+    if (options?.status) {
+      filters.status = options.status
+    }
+
+    if (options?.isVirtual !== undefined) {
+      filters.is_virtual = options.isVirtual
+    }
+
+    try {
+      const result = await this.request<QueryResult<Event>>(
+        `/v1/projects/${this.config.projectId}/tables/strapi_events/rows/query`,
+        'POST',
+        {
+          filter: filters,
+          limit: options?.limit || 20,
+          offset: options?.offset || 0,
+          sort: { start_date: 1 },
+        }
+      )
+
+      return {
+        events: result.rows,
+        total: result.total_count,
+      }
+    } catch (error) {
+      console.error('[Strapi] Failed to fetch events:', error)
+      return { events: [], total: 0 }
+    }
+  }
+
+  /**
+   * Get a single event by slug
+   */
+  async getEventBySlug(slug: string): Promise<Event | null> {
+    if (!this.isConfigured()) {
+      return null
+    }
+
+    try {
+      const result = await this.request<QueryResult<Event>>(
+        `/v1/projects/${this.config.projectId}/tables/strapi_events/rows/query`,
+        'POST',
+        {
+          filter: { slug, published_at: { $ne: null } },
+          limit: 1,
+        }
+      )
+
+      return result.rows[0] || null
+    } catch (error) {
+      console.error('[Strapi] Failed to fetch event:', error)
+      return null
+    }
+  }
+}
+
+// Export singleton instance
+export const strapiClient = new StrapiClient()
+
+// Export types
+export type { ZeroDBConfig, QueryResult }


### PR DESCRIPTION
## Summary
- Implements Story 16.5c: Add blog filtering and pagination
- Adds client-side filtering with URL state management for shareable filtered views
- Creates reusable Pagination and BlogFilters components
- Implements BlogListClient component for filtering/pagination logic
- Updates StructuredData to support BlogPost schema

## Changes
- **BlogListClient**: Main client component handling filtering and pagination with URL state
- **BlogFilters**: Category dropdown and tag checkboxes for filtering posts
- **Pagination**: Previous/next navigation with page indicator
- **BlogCard**: Post preview component for blog listing
- **Strapi client**: API client for fetching blog posts from ZeroDB
- **StructuredData**: Added 'blog' type for BlogPost structured data

## Features
- Filter by category (single select dropdown)
- Filter by tags (multi-select with OR logic)
- Combined category+tag filtering (AND logic)
- Pagination with configurable posts per page
- URL-based state for shareable filtered/paginated views
- Results count showing filtered totals
- Empty state with clear filters option

## Test plan
- [x] All 60 new unit tests pass for filtering and pagination components
- [x] All 176 total unit tests pass
- [x] Vite build succeeds
- [x] Next.js static export builds successfully
- [ ] Manual testing: Filter by category
- [ ] Manual testing: Filter by tags
- [ ] Manual testing: Pagination navigation
- [ ] Manual testing: URL sharing preserves filters

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)