### PR TITLE
feat(papers): Enhance paper page styling for CV presentation (#180)

### DIFF
--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -43,6 +43,7 @@ const Navigation = ({ className = '' }: NavigationProps) => {
       className={cn(
         "relative flex flex-col md:flex-col p-4",
         "bg-[var(--color-bg-primary)] border-b border-[var(--color-border-light)]",
+        "print:hidden",
         className
       )}
       aria-label="Main navigation"

--- a/app/components/PaperCitation.tsx
+++ b/app/components/PaperCitation.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+/**
+ * PaperCitation Component
+ * Story 16.7a: Citation block for academic papers
+ *
+ * Provides a formatted citation in APA-like style with copy functionality.
+ */
+
+import { useState } from 'react'
+import type { Paper } from '../../src/data/papers'
+
+interface PaperCitationProps {
+  paper: Paper
+  author?: string
+}
+
+function formatAuthorForCitation(fullName: string): string {
+  // Convert "Karsten Wade" to "Wade, K."
+  const parts = fullName.trim().split(' ')
+  if (parts.length >= 2) {
+    const lastName = parts[parts.length - 1]
+    const firstInitial = parts[0].charAt(0)
+    return `${lastName}, ${firstInitial}.`
+  }
+  return fullName
+}
+
+function getYear(dateStr: string): string {
+  return new Date(dateStr).getFullYear().toString()
+}
+
+function generateCitation(paper: Paper, author: string): string {
+  const formattedAuthor = formatAuthorForCitation(author)
+  const year = getYear(paper.publicationDate)
+  const url = `https://karstenwade.com/papers/${paper.slug}`
+
+  return `${formattedAuthor} (${year}). ${paper.title}. Retrieved from ${url}`
+}
+
+const PaperCitation = ({ paper, author = 'Karsten Wade' }: PaperCitationProps) => {
+  const [copied, setCopied] = useState(false)
+  const citationText = generateCitation(paper, author)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(citationText)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback for older browsers
+      const textArea = document.createElement('textarea')
+      textArea.value = citationText
+      document.body.appendChild(textArea)
+      textArea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textArea)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  return (
+    <aside
+      className="paper-citation print:hidden bg-gray-50 border border-gray-200 rounded-lg p-4 mt-8"
+      data-testid="paper-citation"
+    >
+      <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
+        Cite this paper
+      </h3>
+      <p
+        className="text-gray-600 text-sm font-mono bg-white p-3 rounded border border-gray-200 mb-3"
+        data-testid="paper-citation-text"
+      >
+        {citationText}
+      </p>
+      <button
+        onClick={handleCopy}
+        className="px-4 py-2 text-sm bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
+        aria-label="Copy citation"
+      >
+        {copied ? 'Copied!' : 'Copy citation'}
+      </button>
+    </aside>
+  )
+}
+
+export default PaperCitation

--- a/app/components/PaperHeader.tsx
+++ b/app/components/PaperHeader.tsx
@@ -1,0 +1,135 @@
+/**
+ * PaperHeader Component
+ * Story 16.7a: Enhanced paper header with CV-quality styling
+ *
+ * Displays paper metadata with professional academic styling
+ * suitable for CV/resume presentation.
+ */
+
+import type { Paper } from '../../src/data/papers'
+
+interface PaperHeaderProps {
+  paper: Paper
+  author?: string
+  showAbstract?: boolean
+  showTags?: boolean
+  showActions?: boolean
+}
+
+function formatDate(dateStr: string): string {
+  // Parse as local date to avoid timezone shifts
+  const [year, month, day] = dateStr.split('-').map(Number)
+  const date = new Date(year, month - 1, day)
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+const PaperHeader = ({
+  paper,
+  author = 'Karsten Wade',
+  showAbstract = false,
+  showTags = false,
+  showActions = false,
+}: PaperHeaderProps) => {
+  const showLastUpdated =
+    paper.lastUpdated && paper.lastUpdated !== paper.publicationDate
+
+  return (
+    <header className="paper-header mb-8">
+      {/* Title with professional serif font */}
+      <h1 className="paper-header__title text-3xl md:text-4xl font-bold font-serif text-gray-900 mb-4 leading-tight">
+        {paper.title}
+      </h1>
+
+      {/* Author attribution */}
+      <div className="paper-header__author text-lg text-gray-700 mb-3">
+        <span className="text-gray-500">Author: </span>
+        <span className="font-medium">{author}</span>
+      </div>
+
+      {/* Metadata row */}
+      <div className="paper-header__meta flex flex-wrap items-center gap-4 text-sm text-gray-600 mb-4">
+        <span className="paper-header__category bg-blue-100 text-blue-800 px-3 py-1 rounded-full font-medium">
+          {paper.category}
+        </span>
+        <span className="paper-header__version text-gray-500">
+          Version {paper.version}
+        </span>
+        <time
+          className="paper-header__date"
+          dateTime={paper.publicationDate}
+        >
+          {formatDate(paper.publicationDate)}
+        </time>
+      </div>
+
+      {/* Last updated (if different from publication date) */}
+      {showLastUpdated && (
+        <p className="paper-header__updated text-sm text-gray-500 mb-4">
+          Last updated:{' '}
+          <time dateTime={paper.lastUpdated}>
+            {formatDate(paper.lastUpdated)}
+          </time>
+        </p>
+      )}
+
+      {/* Abstract with academic styling */}
+      {showAbstract && paper.abstract && (
+        <div className="paper-header__abstract bg-gray-50 border-l-4 border-blue-500 p-4 mb-6">
+          <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-2">
+            Abstract
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            {paper.abstract}
+          </p>
+        </div>
+      )}
+
+      {/* Tags */}
+      {showTags && paper.tags && paper.tags.length > 0 && (
+        <div className="paper-header__tags flex flex-wrap gap-2 mb-6">
+          {paper.tags.map((tag) => (
+            <span
+              key={tag}
+              className="paper-header__tag bg-gray-100 text-gray-700 px-3 py-1 rounded-full text-sm"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Action buttons (hidden in print) */}
+      {showActions && (
+        <div
+          className="paper-header__actions print:hidden flex flex-wrap gap-4"
+          data-testid="paper-actions"
+        >
+          {paper.pdfUrl && (
+            <a
+              href={paper.pdfUrl}
+              className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Download PDF
+            </a>
+          )}
+          <a
+            href={paper.externalUrl}
+            className="px-6 py-3 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View on GitHub
+          </a>
+        </div>
+      )}
+    </header>
+  )
+}
+
+export default PaperHeader

--- a/app/components/PrintButton.tsx
+++ b/app/components/PrintButton.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+/**
+ * PrintButton Component
+ * Story 16.7a: Print button for paper pages
+ *
+ * Provides a button to trigger browser print dialog.
+ * Hidden in print mode via Tailwind's print: variant.
+ */
+
+const PrintButton = () => {
+  const handlePrint = () => {
+    window.print()
+  }
+
+  return (
+    <button
+      onClick={handlePrint}
+      className="print:hidden flex items-center gap-2 px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors"
+      aria-label="Print this paper"
+    >
+      <svg
+        data-testid="print-icon"
+        className="w-5 h-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+        />
+      </svg>
+      <span>Print</span>
+    </button>
+  )
+}
+
+export default PrintButton

--- a/app/papers/[slug]/page.tsx
+++ b/app/papers/[slug]/page.tsx
@@ -8,6 +8,10 @@ import { getPaperBySlug } from '@/services/paperService'
 import Navigation from '../../components/Navigation'
 import StructuredData from '../../components/StructuredData'
 import PdfDownloadButton from '../../components/PdfDownloadButton'
+import PaperHeader from '../../components/PaperHeader'
+import PaperCitation from '../../components/PaperCitation'
+import PrintButton from '../../components/PrintButton'
+import './print.css'
 
 interface PaperDetailProps {
   params: Promise<{ slug: string }>
@@ -45,15 +49,6 @@ export async function generateMetadata({ params }: PaperDetailProps): Promise<Me
   }
 }
 
-function formatDate(dateStr: string): string {
-  const date = new Date(dateStr)
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
-}
-
 export default async function PaperDetail({ params }: PaperDetailProps) {
   const { slug } = await params
 
@@ -81,8 +76,9 @@ export default async function PaperDetail({ params }: PaperDetailProps) {
       <Navigation />
       <StructuredData type="paper" data={paper} />
 
-      <main className="paper-detail max-w-4xl mx-auto px-4 py-8">
-        <nav className="paper-detail__breadcrumb mb-6">
+      <main className="paper-detail max-w-4xl mx-auto px-4 py-8 print:max-w-none print:px-8">
+        {/* Breadcrumb - hidden in print */}
+        <nav className="paper-detail__breadcrumb mb-6 print:hidden">
           <Link
             href="/papers"
             className="text-blue-600 hover:underline"
@@ -92,109 +88,86 @@ export default async function PaperDetail({ params }: PaperDetailProps) {
         </nav>
 
         <article className="paper-detail__article">
-          <header className="paper-detail__header mb-8">
-            <h1 className="paper-detail__title text-3xl md:text-4xl font-bold text-gray-900 mb-4">
-              {paper.title}
-            </h1>
+          {/* Enhanced CV-quality header */}
+          <PaperHeader
+            paper={paper}
+            author="Karsten Wade"
+            showAbstract={!markdownContent}
+            showTags
+          />
 
-            <div className="paper-detail__meta flex flex-wrap gap-4 text-sm text-gray-600 mb-4">
-              <span className="paper-detail__category bg-blue-100 text-blue-800 px-3 py-1 rounded-full">
-                {paper.category}
-              </span>
-              <span className="paper-detail__version">v{paper.version}</span>
-              <time className="paper-detail__date" dateTime={paper.publicationDate}>
-                {formatDate(paper.publicationDate)}
-              </time>
-            </div>
-
-            {!markdownContent && (
-              <p className="paper-detail__abstract text-lg text-gray-700 leading-relaxed mb-6">
-                {paper.abstract}
-              </p>
-            )}
-
-            <div className="paper-detail__tags flex flex-wrap gap-2 mb-6">
-              {paper.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="paper-detail__tag bg-gray-100 text-gray-700 px-3 py-1 rounded-full text-sm"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-
-            <div className="paper-detail__actions flex flex-wrap gap-4">
-              {paper.pdfUrl ? (
-                <a
-                  href={paper.pdfUrl}
-                  className="paper-detail__action px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Download PDF
-                </a>
-              ) : markdownContent ? (
-                <PdfDownloadButton
-                  paperTitle={paper.title}
-                  contentSelector=".paper-detail__article"
-                />
-              ) : null}
+          {/* Action buttons - separate section, hidden in print */}
+          <div className="paper-detail__actions flex flex-wrap gap-4 mb-8 print:hidden">
+            {paper.pdfUrl ? (
               <a
-                href={paper.externalUrl}
-                className="paper-detail__action px-6 py-3 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors"
+                href={paper.pdfUrl}
+                className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                View on GitHub
+                Download PDF
               </a>
-            </div>
-          </header>
+            ) : markdownContent ? (
+              <PdfDownloadButton
+                paperTitle={paper.title}
+                contentSelector=".paper-detail__article"
+              />
+            ) : null}
+            <a
+              href={paper.externalUrl}
+              className="px-6 py-3 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View on GitHub
+            </a>
+            <PrintButton />
+          </div>
 
           {/* Full paper content rendered from markdown */}
           {markdownContent && (
-            <section className="paper-detail__content prose prose-lg max-w-none mb-8">
+            <section className="paper-detail__content prose prose-lg max-w-none mb-8 print:prose-sm">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 components={{
-                  // Style headings
+                  // Style headings - use serif for academic look
                   h1: ({ children }) => (
-                    <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4 border-b pb-2">
+                    <h2 className="text-2xl font-bold font-serif text-gray-900 mt-8 mb-4 border-b pb-2 print:mt-6 print:mb-3">
                       {children}
                     </h2>
                   ),
                   h2: ({ children }) => (
-                    <h3 className="text-xl font-semibold text-gray-800 mt-6 mb-3">
+                    <h3 className="text-xl font-semibold font-serif text-gray-800 mt-6 mb-3 print:mt-4 print:mb-2">
                       {children}
                     </h3>
                   ),
                   h3: ({ children }) => (
-                    <h4 className="text-lg font-medium text-gray-700 mt-4 mb-2">
+                    <h4 className="text-lg font-medium text-gray-700 mt-4 mb-2 print:mt-3">
                       {children}
                     </h4>
                   ),
                   // Style paragraphs
                   p: ({ children }) => (
-                    <p className="text-gray-700 leading-relaxed mb-4">
+                    <p className="text-gray-700 leading-relaxed mb-4 print:mb-3 print:text-sm">
                       {children}
                     </p>
                   ),
                   // Style lists
                   ul: ({ children }) => (
-                    <ul className="list-disc list-inside mb-4 space-y-1 text-gray-700">
+                    <ul className="list-disc list-inside mb-4 space-y-1 text-gray-700 print:mb-3 print:text-sm">
                       {children}
                     </ul>
                   ),
                   ol: ({ children }) => (
-                    <ol className="list-decimal list-inside mb-4 space-y-1 text-gray-700">
+                    <ol className="list-decimal list-inside mb-4 space-y-1 text-gray-700 print:mb-3 print:text-sm">
                       {children}
                     </ol>
                   ),
-                  // Style links
+                  // Style links - show URL in print
                   a: ({ href, children }) => (
                     <a
                       href={href}
-                      className="text-blue-600 hover:underline"
+                      className="text-blue-600 hover:underline print:text-gray-900 print:underline"
                       target={href?.startsWith('http') ? '_blank' : undefined}
                       rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
                     >
@@ -203,7 +176,7 @@ export default async function PaperDetail({ params }: PaperDetailProps) {
                   ),
                   // Style blockquotes
                   blockquote: ({ children }) => (
-                    <blockquote className="border-l-4 border-blue-500 pl-4 my-4 italic text-gray-600">
+                    <blockquote className="border-l-4 border-blue-500 pl-4 my-4 italic text-gray-600 print:border-gray-400">
                       {children}
                     </blockquote>
                   ),
@@ -212,13 +185,13 @@ export default async function PaperDetail({ params }: PaperDetailProps) {
                     const isInline = !className
                     if (isInline) {
                       return (
-                        <code className="bg-gray-100 px-1 py-0.5 rounded text-sm font-mono">
+                        <code className="bg-gray-100 px-1 py-0.5 rounded text-sm font-mono print:bg-gray-50">
                           {children}
                         </code>
                       )
                     }
                     return (
-                      <code className="block bg-gray-100 p-4 rounded-lg overflow-x-auto text-sm font-mono">
+                      <code className="block bg-gray-100 p-4 rounded-lg overflow-x-auto text-sm font-mono print:bg-gray-50 print:text-xs">
                         {children}
                       </code>
                     )
@@ -226,18 +199,18 @@ export default async function PaperDetail({ params }: PaperDetailProps) {
                   // Style tables
                   table: ({ children }) => (
                     <div className="overflow-x-auto mb-4">
-                      <table className="min-w-full border-collapse border border-gray-300">
+                      <table className="min-w-full border-collapse border border-gray-300 print:text-sm">
                         {children}
                       </table>
                     </div>
                   ),
                   th: ({ children }) => (
-                    <th className="border border-gray-300 px-4 py-2 bg-gray-100 font-semibold text-left">
+                    <th className="border border-gray-300 px-4 py-2 bg-gray-100 font-semibold text-left print:px-2 print:py-1">
                       {children}
                     </th>
                   ),
                   td: ({ children }) => (
-                    <td className="border border-gray-300 px-4 py-2">
+                    <td className="border border-gray-300 px-4 py-2 print:px-2 print:py-1">
                       {children}
                     </td>
                   ),
@@ -248,27 +221,27 @@ export default async function PaperDetail({ params }: PaperDetailProps) {
             </section>
           )}
 
-          <footer className="paper-detail__footer pt-6 border-t border-gray-200">
-            <p className="paper-detail__repository text-gray-600">
+          {/* Citation block - hidden in print */}
+          <PaperCitation paper={paper} author="Karsten Wade" />
+
+          {/* Footer */}
+          <footer className="paper-detail__footer pt-6 border-t border-gray-200 mt-8">
+            <p className="paper-detail__repository text-gray-600 print:text-sm">
               This paper is maintained in the{' '}
               <a
                 href={paper.repository}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:underline"
+                className="text-blue-600 hover:underline print:text-gray-900"
               >
                 karstenwade/papers
               </a>{' '}
               repository.
             </p>
-            {paper.lastUpdated && paper.lastUpdated !== paper.publicationDate && (
-              <p className="paper-detail__updated text-sm text-gray-500 mt-2">
-                Last updated:{' '}
-                <time dateTime={paper.lastUpdated}>
-                  {formatDate(paper.lastUpdated)}
-                </time>
-              </p>
-            )}
+            {/* Print-only: Show URL */}
+            <p className="hidden print:block text-xs text-gray-500 mt-2">
+              URL: https://karstenwade.com/papers/{paper.slug}
+            </p>
           </footer>
         </article>
       </main>

--- a/app/papers/[slug]/print.css
+++ b/app/papers/[slug]/print.css
@@ -1,0 +1,146 @@
+/**
+ * Print Stylesheet for Paper Pages
+ * Story 16.7a: Print-friendly styling for CV presentation
+ *
+ * This stylesheet is imported into the paper detail page layout
+ * to provide professional print output suitable for academic/CV use.
+ */
+
+@media print {
+  /* Page setup */
+  @page {
+    size: letter;
+    margin: 1in;
+  }
+
+  /* Hide non-essential elements */
+  nav,
+  .paper-detail__breadcrumb,
+  .paper-detail__actions,
+  .paper-citation,
+  button,
+  [class*="print:hidden"] {
+    display: none !important;
+  }
+
+  /* Typography enhancements for print */
+  body {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    font-size: 11pt;
+    line-height: 1.5;
+    color: #000;
+    background: #fff;
+  }
+
+  /* Header styling */
+  .paper-header__title {
+    font-size: 18pt;
+    font-weight: bold;
+    margin-bottom: 0.5em;
+    page-break-after: avoid;
+  }
+
+  .paper-header__author {
+    font-size: 12pt;
+    margin-bottom: 0.25em;
+  }
+
+  .paper-header__meta {
+    font-size: 10pt;
+    color: #333;
+    margin-bottom: 1em;
+  }
+
+  /* Abstract styling */
+  .paper-header__abstract {
+    border-left: 3px solid #666;
+    padding-left: 1em;
+    margin: 1em 0;
+    font-style: italic;
+  }
+
+  /* Content styling */
+  .paper-detail__content {
+    font-size: 11pt;
+  }
+
+  .paper-detail__content h2,
+  .paper-detail__content h3,
+  .paper-detail__content h4 {
+    page-break-after: avoid;
+    margin-top: 1.5em;
+  }
+
+  .paper-detail__content p {
+    orphans: 3;
+    widows: 3;
+  }
+
+  /* Links - show URL for important links */
+  .paper-detail__content a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 9pt;
+    color: #666;
+    word-break: break-all;
+  }
+
+  /* Don't show URL for internal links */
+  .paper-detail__content a[href^="/"]::after {
+    content: none;
+  }
+
+  /* Code blocks */
+  .paper-detail__content code {
+    background: #f5f5f5;
+    border: 1px solid #ddd;
+    font-size: 9pt;
+  }
+
+  /* Tables */
+  .paper-detail__content table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 10pt;
+  }
+
+  .paper-detail__content th,
+  .paper-detail__content td {
+    border: 1px solid #333;
+    padding: 0.5em;
+  }
+
+  /* Footer */
+  .paper-detail__footer {
+    margin-top: 2em;
+    padding-top: 1em;
+    border-top: 1px solid #999;
+    font-size: 10pt;
+  }
+
+  /* Page breaks */
+  .paper-detail__article {
+    page-break-inside: avoid;
+  }
+
+  .paper-detail__content section {
+    page-break-inside: avoid;
+  }
+
+  /* Tags - more compact for print */
+  .paper-header__tags {
+    font-size: 9pt;
+  }
+
+  .paper-header__tag {
+    background: #f0f0f0;
+    border: 1px solid #ccc;
+    padding: 0.1em 0.5em;
+  }
+
+  /* Category badge */
+  .paper-header__category {
+    background: #e8e8e8;
+    border: 1px solid #999;
+    color: #333;
+  }
+}

--- a/app/papers/__tests__/PaperDetail.test.tsx
+++ b/app/papers/__tests__/PaperDetail.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * PaperDetail Page Tests
+ * Story 16.7a: Enhance paper page styling
+ *
+ * RED PHASE: These tests define the expected behavior for CV-quality paper styling.
+ *
+ * Requirements:
+ * - Enhanced styling for CV/resume presentation
+ * - Print-friendly layout
+ * - Author attribution section
+ * - Citation format
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+}))
+
+// Mock next/script to avoid issues with Script component
+vi.mock('next/script', () => ({
+  default: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => (
+    <script {...props}>{children}</script>
+  ),
+}))
+
+// We'll test the presentational components that make up the paper detail page
+
+import PaperHeader from '../../components/PaperHeader'
+import PaperCitation from '../../components/PaperCitation'
+import PrintButton from '../../components/PrintButton'
+import type { Paper } from '../../../src/data/papers'
+
+const mockPaper: Paper = {
+  slug: 'test-paper',
+  title: 'Test Paper Title',
+  description: 'Test description',
+  abstract: 'This is a test abstract for the paper.',
+  externalUrl: 'https://github.com/karstenwade/papers/blob/main/test.md',
+  repository: 'https://github.com/karstenwade/papers',
+  publicationDate: '2025-01-15',
+  lastUpdated: '2025-02-20',
+  version: '1.2',
+  category: 'Test Category',
+  tags: ['test', 'example', 'vitest'],
+  featured: true,
+}
+
+describe('PaperHeader Component', () => {
+  describe('CV-quality styling', () => {
+    it('renders the paper title with professional styling', () => {
+      render(<PaperHeader paper={mockPaper} />)
+
+      const title = screen.getByRole('heading', { level: 1 })
+      expect(title).toHaveTextContent('Test Paper Title')
+      // Check for professional font styling class
+      expect(title).toHaveClass('font-serif')
+    })
+
+    it('displays author attribution', () => {
+      render(<PaperHeader paper={mockPaper} author="Karsten Wade" />)
+
+      expect(screen.getByText(/Karsten Wade/)).toBeInTheDocument()
+      expect(screen.getByText(/Author/i)).toBeInTheDocument()
+    })
+
+    it('shows version and publication date in academic format', () => {
+      render(<PaperHeader paper={mockPaper} />)
+
+      // Academic date format: "January 15, 2025"
+      expect(screen.getByText(/January 15, 2025/)).toBeInTheDocument()
+      expect(screen.getByText(/Version 1.2/)).toBeInTheDocument()
+    })
+
+    it('displays category as a badge', () => {
+      render(<PaperHeader paper={mockPaper} />)
+
+      const badge = screen.getByText('Test Category')
+      expect(badge).toHaveClass('paper-header__category')
+    })
+
+    it('renders abstract with proper academic styling', () => {
+      render(<PaperHeader paper={mockPaper} showAbstract />)
+
+      // Check for Abstract heading (use getByRole to be more specific)
+      expect(screen.getByRole('heading', { name: /Abstract/i })).toBeInTheDocument()
+      expect(screen.getByText('This is a test abstract for the paper.')).toBeInTheDocument()
+    })
+
+    it('applies print-hidden class to action buttons', () => {
+      render(<PaperHeader paper={mockPaper} showActions />)
+
+      const actions = screen.getByTestId('paper-actions')
+      expect(actions).toHaveClass('print:hidden')
+    })
+  })
+
+  describe('metadata display', () => {
+    it('shows last updated date when different from publication date', () => {
+      render(<PaperHeader paper={mockPaper} />)
+
+      expect(screen.getByText(/Last updated/i)).toBeInTheDocument()
+      expect(screen.getByText(/February 20, 2025/)).toBeInTheDocument()
+    })
+
+    it('hides last updated when same as publication date', () => {
+      const sameDatePaper = { ...mockPaper, lastUpdated: mockPaper.publicationDate }
+      render(<PaperHeader paper={sameDatePaper} />)
+
+      expect(screen.queryByText(/Last updated/i)).not.toBeInTheDocument()
+    })
+
+    it('displays tags with professional styling', () => {
+      render(<PaperHeader paper={mockPaper} showTags />)
+
+      expect(screen.getByText('test')).toBeInTheDocument()
+      expect(screen.getByText('example')).toBeInTheDocument()
+      expect(screen.getByText('vitest')).toBeInTheDocument()
+    })
+  })
+})
+
+describe('PaperCitation Component', () => {
+  it('generates a proper citation format', () => {
+    render(<PaperCitation paper={mockPaper} author="Karsten Wade" />)
+
+    // Should show a citation block
+    expect(screen.getByText(/Cite this paper/i)).toBeInTheDocument()
+  })
+
+  it('displays citation in APA-like format', () => {
+    render(<PaperCitation paper={mockPaper} author="Karsten Wade" />)
+
+    // APA-like: Author (Year). Title. Retrieved from URL
+    const citation = screen.getByTestId('paper-citation-text')
+    expect(citation).toHaveTextContent('Wade, K.')
+    expect(citation).toHaveTextContent('2025')
+    expect(citation).toHaveTextContent('Test Paper Title')
+  })
+
+  it('provides a copy citation button', () => {
+    render(<PaperCitation paper={mockPaper} author="Karsten Wade" />)
+
+    expect(screen.getByRole('button', { name: /copy citation/i })).toBeInTheDocument()
+  })
+
+  it('hides citation in print mode', () => {
+    render(<PaperCitation paper={mockPaper} author="Karsten Wade" />)
+
+    const citationSection = screen.getByTestId('paper-citation')
+    expect(citationSection).toHaveClass('print:hidden')
+  })
+})
+
+describe('PrintButton Component', () => {
+  beforeEach(() => {
+    // Mock window.print
+    vi.stubGlobal('print', vi.fn())
+  })
+
+  it('renders a print button', () => {
+    render(<PrintButton />)
+
+    expect(screen.getByRole('button', { name: /print/i })).toBeInTheDocument()
+  })
+
+  it('has print icon', () => {
+    render(<PrintButton />)
+
+    // Check for printer icon (either text or SVG)
+    expect(screen.getByTestId('print-icon')).toBeInTheDocument()
+  })
+
+  it('is hidden in print mode', () => {
+    render(<PrintButton />)
+
+    const button = screen.getByRole('button', { name: /print/i })
+    expect(button).toHaveClass('print:hidden')
+  })
+
+  it('calls window.print when clicked', async () => {
+    const userEvent = await import('@testing-library/user-event')
+    const user = userEvent.default.setup()
+
+    render(<PrintButton />)
+
+    await user.click(screen.getByRole('button', { name: /print/i }))
+
+    expect(window.print).toHaveBeenCalled()
+  })
+})
+
+describe('Print Styles', () => {
+  // These tests verify that print-specific CSS classes exist
+  // The actual print stylesheet will be tested via visual regression or manual testing
+
+  it('has print:hidden utility available for non-print elements', () => {
+    render(
+      <div>
+        <nav className="print:hidden">Navigation</nav>
+        <main>Content</main>
+      </div>
+    )
+
+    const nav = screen.getByText('Navigation')
+    expect(nav).toHaveClass('print:hidden')
+  })
+
+  it('content area should not be hidden in print', () => {
+    render(
+      <main className="paper-content" data-testid="paper-content">
+        Paper Content
+      </main>
+    )
+
+    const content = screen.getByTestId('paper-content')
+    expect(content).not.toHaveClass('print:hidden')
+  })
+})


### PR DESCRIPTION
## Summary
- Add CV-quality styling for paper detail pages with professional academic presentation
- Implement PaperHeader, PaperCitation, and PrintButton components
- Add print-friendly stylesheet with optimized typography

## Changes
### New Components
- **PaperHeader**: Professional header with serif fonts, author attribution, version/date display
- **PaperCitation**: APA-like citation block with copy-to-clipboard functionality
- **PrintButton**: Print trigger button with printer icon

### Print Stylesheet (`print.css`)
- Hides navigation, buttons, and interactive elements in print
- Uses Georgia/Times New Roman for professional print output
- Shows URLs for external links in printed documents
- Prevents widows/orphans in paragraphs
- Proper @page rules for letter-size paper with 1" margins

### Other Changes
- Navigation component now hidden in print mode
- Paper detail page refactored to use new components

## Test plan
- [x] All 515 unit tests pass (19 new tests added)
- [x] Next.js build succeeds
- [x] Vite build succeeds
- [ ] Visual review: paper page displays with professional styling
- [ ] Print preview: navigation hidden, typography optimized
- [ ] Copy citation button works correctly

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)