### PR TITLE
feat(papers): Add citation formats and structured data (#181)

### DIFF
--- a/app/components/CitationBlock.tsx
+++ b/app/components/CitationBlock.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+/**
+ * CitationBlock Component
+ * Story 16.7b: Multiple citation format display
+ *
+ * Provides citations in APA, MLA, and BibTeX formats with tabbed interface.
+ */
+
+import { useState } from 'react'
+import type { Paper } from '../../src/data/papers'
+
+type CitationFormat = 'apa' | 'mla' | 'bibtex'
+
+interface CitationBlockProps {
+  paper: Paper
+  author?: string
+}
+
+function formatAuthorAPA(fullName: string): string {
+  // Convert "Karsten Wade" to "Wade, K."
+  const parts = fullName.trim().split(' ')
+  if (parts.length >= 2) {
+    const lastName = parts[parts.length - 1]
+    const firstInitial = parts[0].charAt(0)
+    return `${lastName}, ${firstInitial}.`
+  }
+  return fullName
+}
+
+function formatAuthorMLA(fullName: string): string {
+  // Convert "Karsten Wade" to "Wade, Karsten"
+  const parts = fullName.trim().split(' ')
+  if (parts.length >= 2) {
+    const lastName = parts[parts.length - 1]
+    const firstName = parts.slice(0, -1).join(' ')
+    return `${lastName}, ${firstName}`
+  }
+  return fullName
+}
+
+function formatAuthorBibTeX(fullName: string): string {
+  // BibTeX uses "Lastname, Firstname" format
+  const parts = fullName.trim().split(' ')
+  if (parts.length >= 2) {
+    const lastName = parts[parts.length - 1]
+    const firstName = parts.slice(0, -1).join(' ')
+    return `${lastName}, ${firstName}`
+  }
+  return fullName
+}
+
+function getYear(dateStr: string): string {
+  return new Date(dateStr).getFullYear().toString()
+}
+
+function generateBibTeXKey(paper: Paper, author: string): string {
+  const lastName = author.split(' ').pop()?.toLowerCase() || 'unknown'
+  const year = getYear(paper.publicationDate)
+  const slugKey = paper.slug?.split('-')[0] || 'paper'
+  return `${lastName}${year}${slugKey}`
+}
+
+function generateAPACitation(paper: Paper, author: string): string {
+  const formattedAuthor = formatAuthorAPA(author)
+  const year = getYear(paper.publicationDate)
+
+  if (paper.doi) {
+    return `${formattedAuthor} (${year}). ${paper.title}. https://doi.org/${paper.doi}`
+  }
+
+  const url = `https://karstenwade.com/papers/${paper.slug}`
+  return `${formattedAuthor} (${year}). ${paper.title}. Retrieved from ${url}`
+}
+
+function generateMLACitation(paper: Paper, author: string): string {
+  const formattedAuthor = formatAuthorMLA(author)
+  const year = getYear(paper.publicationDate)
+
+  if (paper.doi) {
+    return `${formattedAuthor}. "${paper.title}." karstenwade.com, ${year}, https://doi.org/${paper.doi}.`
+  }
+
+  const url = `https://karstenwade.com/papers/${paper.slug}`
+  return `${formattedAuthor}. "${paper.title}." karstenwade.com, ${year}, ${url}.`
+}
+
+function generateBibTeXCitation(paper: Paper, author: string): string {
+  const key = generateBibTeXKey(paper, author)
+  const formattedAuthor = formatAuthorBibTeX(author)
+  const year = getYear(paper.publicationDate)
+  const url = `https://karstenwade.com/papers/${paper.slug}`
+
+  const fields = [
+    `  author = {${formattedAuthor}}`,
+    `  title = {${paper.title}}`,
+    `  year = {${year}}`,
+    `  url = {${url}}`,
+  ]
+
+  if (paper.doi) {
+    fields.push(`  doi = {${paper.doi}}`)
+  }
+
+  return `@article{${key},\n${fields.join(',\n')}\n}`
+}
+
+const CitationBlock = ({ paper, author = 'Karsten Wade' }: CitationBlockProps) => {
+  const [activeFormat, setActiveFormat] = useState<CitationFormat>('apa')
+  const [copied, setCopied] = useState(false)
+
+  const citations = {
+    apa: generateAPACitation(paper, author),
+    mla: generateMLACitation(paper, author),
+    bibtex: generateBibTeXCitation(paper, author),
+  }
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(citations[activeFormat])
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback for older browsers
+      const textArea = document.createElement('textarea')
+      textArea.value = citations[activeFormat]
+      document.body.appendChild(textArea)
+      textArea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textArea)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  const tabs: { id: CitationFormat; label: string }[] = [
+    { id: 'apa', label: 'APA' },
+    { id: 'mla', label: 'MLA' },
+    { id: 'bibtex', label: 'BibTeX' },
+  ]
+
+  return (
+    <aside
+      className="citation-block print:hidden bg-gray-50 border border-gray-200 rounded-lg p-4 mt-8"
+      data-testid="citation-block"
+    >
+      <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-3">
+        Cite this paper
+      </h3>
+
+      {/* DOI display */}
+      {paper.doi && (
+        <div className="mb-3 text-sm">
+          <span className="font-medium text-gray-600">DOI: </span>
+          <a
+            href={`https://doi.org/${paper.doi}`}
+            className="text-blue-600 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {paper.doi}
+          </a>
+        </div>
+      )}
+
+      {/* Format tabs */}
+      <div
+        role="tablist"
+        aria-label="Citation format selector"
+        className="flex gap-1 mb-3 border-b border-gray-200"
+      >
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            id={`tab-${tab.id}`}
+            aria-selected={activeFormat === tab.id}
+            aria-controls={`panel-${tab.id}`}
+            onClick={() => setActiveFormat(tab.id)}
+            className={`px-3 py-2 text-sm font-medium rounded-t transition-colors ${
+              activeFormat === tab.id
+                ? 'bg-white text-blue-600 border border-gray-200 border-b-white -mb-px'
+                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Citation panel */}
+      <div
+        role="tabpanel"
+        id={`panel-${activeFormat}`}
+        aria-labelledby={`tab-${activeFormat}`}
+        className={`bg-white p-3 rounded border border-gray-200 mb-3 ${
+          activeFormat === 'bibtex' ? 'font-mono text-xs' : 'text-sm'
+        }`}
+      >
+        <pre className="whitespace-pre-wrap break-words text-gray-700">
+          {citations[activeFormat]}
+        </pre>
+      </div>
+
+      {/* Copy button */}
+      <button
+        onClick={handleCopy}
+        className="px-4 py-2 text-sm bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
+        aria-label="Copy citation"
+      >
+        {copied ? 'Copied!' : 'Copy citation'}
+      </button>
+    </aside>
+  )
+}
+
+export default CitationBlock

--- a/app/components/StructuredData.tsx
+++ b/app/components/StructuredData.tsx
@@ -132,6 +132,14 @@ const StructuredData = ({ type, data }: StructuredDataProps) => {
       keywords: paper.tags.join(', '),
       inLanguage: 'en-US',
       version: paper.version,
+      ...(paper.doi && {
+        identifier: {
+          '@type': 'PropertyValue',
+          propertyID: 'DOI',
+          value: paper.doi,
+        },
+        sameAs: `https://doi.org/${paper.doi}`,
+      }),
     }
   } else if (type === 'blog' && data) {
     // Schema.org BlogPosting for blog posts

--- a/app/papers/[slug]/page.tsx
+++ b/app/papers/[slug]/page.tsx
@@ -9,7 +9,7 @@ import Navigation from '../../components/Navigation'
 import StructuredData from '../../components/StructuredData'
 import PdfDownloadButton from '../../components/PdfDownloadButton'
 import PaperHeader from '../../components/PaperHeader'
-import PaperCitation from '../../components/PaperCitation'
+import CitationBlock from '../../components/CitationBlock'
 import PrintButton from '../../components/PrintButton'
 import './print.css'
 
@@ -222,7 +222,7 @@ export default async function PaperDetail({ params }: PaperDetailProps) {
           )}
 
           {/* Citation block - hidden in print */}
-          <PaperCitation paper={paper} author="Karsten Wade" />
+          <CitationBlock paper={paper} author="Karsten Wade" />
 
           {/* Footer */}
           <footer className="paper-detail__footer pt-6 border-t border-gray-200 mt-8">

--- a/app/papers/__tests__/CitationBlock.test.tsx
+++ b/app/papers/__tests__/CitationBlock.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * CitationBlock Component Tests
+ * Story 16.7b: Add citation and structured data
+ *
+ * RED PHASE: Tests for multiple citation formats and DOI display.
+ *
+ * Requirements:
+ * - Display citations in APA, MLA, and BibTeX formats
+ * - Allow switching between formats via tabs
+ * - Copy citation functionality for each format
+ * - Display DOI when available
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import CitationBlock from '../../components/CitationBlock'
+import type { Paper } from '../../../src/data/papers'
+
+const mockPaper: Paper = {
+  slug: 'test-paper',
+  title: 'Test Paper Title',
+  description: 'Test description',
+  abstract: 'This is a test abstract for the paper.',
+  externalUrl: 'https://github.com/karstenwade/papers/blob/main/test.md',
+  repository: 'https://github.com/karstenwade/papers',
+  publicationDate: '2025-01-15',
+  lastUpdated: '2025-02-20',
+  version: '1.2',
+  category: 'Test Category',
+  tags: ['test', 'example', 'vitest'],
+  featured: true,
+}
+
+const mockPaperWithDoi: Paper = {
+  ...mockPaper,
+  doi: '10.1234/example.2025.001',
+}
+
+describe('CitationBlock Component', () => {
+  beforeEach(() => {
+    // Mock clipboard API for copy tests
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  describe('Format tabs', () => {
+    it('renders format selector tabs', () => {
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      expect(screen.getByRole('tab', { name: /APA/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /MLA/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /BibTeX/i })).toBeInTheDocument()
+    })
+
+    it('defaults to APA format', () => {
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      const apaTab = screen.getByRole('tab', { name: /APA/i })
+      expect(apaTab).toHaveAttribute('aria-selected', 'true')
+    })
+
+    it('switches to MLA format when MLA tab is clicked', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      await user.click(screen.getByRole('tab', { name: /MLA/i }))
+
+      const mlaTab = screen.getByRole('tab', { name: /MLA/i })
+      expect(mlaTab).toHaveAttribute('aria-selected', 'true')
+    })
+
+    it('switches to BibTeX format when BibTeX tab is clicked', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      await user.click(screen.getByRole('tab', { name: /BibTeX/i }))
+
+      const bibtexTab = screen.getByRole('tab', { name: /BibTeX/i })
+      expect(bibtexTab).toHaveAttribute('aria-selected', 'true')
+    })
+  })
+
+  describe('APA format', () => {
+    it('displays citation in APA format', () => {
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      const citationPanel = screen.getByRole('tabpanel')
+      // APA format: Author, F. (Year). Title. URL
+      expect(within(citationPanel).getByText(/Wade, K\./)).toBeInTheDocument()
+      expect(within(citationPanel).getByText(/\(2025\)/)).toBeInTheDocument()
+      expect(within(citationPanel).getByText(/Test Paper Title/)).toBeInTheDocument()
+    })
+
+    it('includes DOI in APA format when available', () => {
+      render(<CitationBlock paper={mockPaperWithDoi} author="Karsten Wade" />)
+
+      const citationPanel = screen.getByRole('tabpanel')
+      expect(within(citationPanel).getByText(/doi\.org\/10\.1234/)).toBeInTheDocument()
+    })
+  })
+
+  describe('MLA format', () => {
+    it('displays citation in MLA format', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      await user.click(screen.getByRole('tab', { name: /MLA/i }))
+
+      const citationPanel = screen.getByRole('tabpanel')
+      // MLA format: Author. "Title." Website, Publisher, Date, URL.
+      expect(within(citationPanel).getByText(/Wade, Karsten/)).toBeInTheDocument()
+      expect(within(citationPanel).getByText(/"Test Paper Title\."/)).toBeInTheDocument()
+    })
+
+    it('includes DOI in MLA format when available', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaperWithDoi} author="Karsten Wade" />)
+
+      await user.click(screen.getByRole('tab', { name: /MLA/i }))
+
+      const citationPanel = screen.getByRole('tabpanel')
+      expect(within(citationPanel).getByText(/doi\.org\/10\.1234/)).toBeInTheDocument()
+    })
+  })
+
+  describe('BibTeX format', () => {
+    it('displays citation in BibTeX format', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      await user.click(screen.getByRole('tab', { name: /BibTeX/i }))
+
+      const citationPanel = screen.getByRole('tabpanel')
+      // BibTeX format: @article{key, author = {...}, title = {...}, ...}
+      expect(within(citationPanel).getByText(/@article\{/)).toBeInTheDocument()
+      expect(within(citationPanel).getByText(/author\s*=/)).toBeInTheDocument()
+      expect(within(citationPanel).getByText(/title\s*=/)).toBeInTheDocument()
+      expect(within(citationPanel).getByText(/year\s*=/)).toBeInTheDocument()
+    })
+
+    it('includes DOI field in BibTeX when available', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaperWithDoi} author="Karsten Wade" />)
+
+      await user.click(screen.getByRole('tab', { name: /BibTeX/i }))
+
+      const citationPanel = screen.getByRole('tabpanel')
+      expect(within(citationPanel).getByText(/doi\s*=/)).toBeInTheDocument()
+    })
+
+    it('uses paper slug as BibTeX key', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      await user.click(screen.getByRole('tab', { name: /BibTeX/i }))
+
+      const citationPanel = screen.getByRole('tabpanel')
+      // Key format: lastname + year + first word of slug
+      expect(within(citationPanel).getByText(/wade2025test/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Copy functionality', () => {
+    it('provides a copy button', () => {
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument()
+    })
+
+    it('copies APA citation when in APA tab', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      // Verify the APA citation is displayed in the panel
+      const citationPanel = screen.getByRole('tabpanel')
+      expect(within(citationPanel).getByText(/Wade, K\./)).toBeInTheDocument()
+      expect(within(citationPanel).getByText(/\(2025\)/)).toBeInTheDocument()
+
+      // Clicking copy triggers the copy action (verified by UI state change)
+      await user.click(screen.getByRole('button', { name: /copy/i }))
+      expect(await screen.findByText(/copied/i)).toBeInTheDocument()
+    })
+
+    it('copies MLA citation when in MLA tab', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      await user.click(screen.getByRole('tab', { name: /MLA/i }))
+
+      // Verify the MLA citation is displayed in the panel
+      const citationPanel = screen.getByRole('tabpanel')
+      expect(within(citationPanel).getByText(/Wade, Karsten/)).toBeInTheDocument()
+
+      // Clicking copy triggers the copy action
+      await user.click(screen.getByRole('button', { name: /copy/i }))
+      expect(await screen.findByText(/copied/i)).toBeInTheDocument()
+    })
+
+    it('copies BibTeX citation when in BibTeX tab', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      await user.click(screen.getByRole('tab', { name: /BibTeX/i }))
+
+      // Verify the BibTeX citation is displayed in the panel
+      const citationPanel = screen.getByRole('tabpanel')
+      expect(within(citationPanel).getByText(/@article\{/)).toBeInTheDocument()
+
+      // Clicking copy triggers the copy action
+      await user.click(screen.getByRole('button', { name: /copy/i }))
+      expect(await screen.findByText(/copied/i)).toBeInTheDocument()
+    })
+
+    it('shows copied confirmation', async () => {
+      const user = userEvent.setup()
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      await user.click(screen.getByRole('button', { name: /copy/i }))
+
+      expect(screen.getByText(/copied/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('DOI display', () => {
+    it('displays DOI when available', () => {
+      render(<CitationBlock paper={mockPaperWithDoi} author="Karsten Wade" />)
+
+      expect(screen.getByText(/DOI:/i)).toBeInTheDocument()
+      // DOI appears in both header link and citation, use link to be specific
+      expect(screen.getByRole('link', { name: /10\.1234\/example\.2025\.001/ })).toBeInTheDocument()
+    })
+
+    it('renders DOI as a clickable link', () => {
+      render(<CitationBlock paper={mockPaperWithDoi} author="Karsten Wade" />)
+
+      const doiLink = screen.getByRole('link', { name: /10\.1234\/example\.2025\.001/ })
+      expect(doiLink).toHaveAttribute('href', 'https://doi.org/10.1234/example.2025.001')
+    })
+
+    it('does not display DOI section when not available', () => {
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      expect(screen.queryByText(/DOI:/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('uses proper tablist/tab/tabpanel structure', () => {
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      expect(screen.getByRole('tablist')).toBeInTheDocument()
+      expect(screen.getAllByRole('tab')).toHaveLength(3)
+      expect(screen.getByRole('tabpanel')).toBeInTheDocument()
+    })
+
+    it('has accessible labels for tabs', () => {
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      const tablist = screen.getByRole('tablist')
+      expect(tablist).toHaveAttribute('aria-label')
+    })
+
+    it('is hidden in print mode', () => {
+      render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
+
+      const citationBlock = screen.getByTestId('citation-block')
+      expect(citationBlock).toHaveClass('print:hidden')
+    })
+  })
+})

--- a/app/papers/__tests__/PaperDetail.test.tsx
+++ b/app/papers/__tests__/PaperDetail.test.tsx
@@ -29,7 +29,7 @@ vi.mock('next/script', () => ({
 // We'll test the presentational components that make up the paper detail page
 
 import PaperHeader from '../../components/PaperHeader'
-import PaperCitation from '../../components/PaperCitation'
+import CitationBlock from '../../components/CitationBlock'
 import PrintButton from '../../components/PrintButton'
 import type { Paper } from '../../../src/data/papers'
 
@@ -122,34 +122,45 @@ describe('PaperHeader Component', () => {
   })
 })
 
-describe('PaperCitation Component', () => {
+describe('CitationBlock Component', () => {
+  beforeEach(() => {
+    // Mock clipboard API for copy tests
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      writable: true,
+      configurable: true,
+    })
+  })
+
   it('generates a proper citation format', () => {
-    render(<PaperCitation paper={mockPaper} author="Karsten Wade" />)
+    render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
 
     // Should show a citation block
     expect(screen.getByText(/Cite this paper/i)).toBeInTheDocument()
   })
 
-  it('displays citation in APA-like format', () => {
-    render(<PaperCitation paper={mockPaper} author="Karsten Wade" />)
+  it('displays citation in APA format by default', () => {
+    render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
 
-    // APA-like: Author (Year). Title. Retrieved from URL
-    const citation = screen.getByTestId('paper-citation-text')
-    expect(citation).toHaveTextContent('Wade, K.')
-    expect(citation).toHaveTextContent('2025')
-    expect(citation).toHaveTextContent('Test Paper Title')
+    // APA format: Author (Year). Title. URL
+    const citationPanel = screen.getByRole('tabpanel')
+    expect(citationPanel).toHaveTextContent('Wade, K.')
+    expect(citationPanel).toHaveTextContent('2025')
+    expect(citationPanel).toHaveTextContent('Test Paper Title')
   })
 
   it('provides a copy citation button', () => {
-    render(<PaperCitation paper={mockPaper} author="Karsten Wade" />)
+    render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
 
     expect(screen.getByRole('button', { name: /copy citation/i })).toBeInTheDocument()
   })
 
   it('hides citation in print mode', () => {
-    render(<PaperCitation paper={mockPaper} author="Karsten Wade" />)
+    render(<CitationBlock paper={mockPaper} author="Karsten Wade" />)
 
-    const citationSection = screen.getByTestId('paper-citation')
+    const citationSection = screen.getByTestId('citation-block')
     expect(citationSection).toHaveClass('print:hidden')
   })
 })

--- a/src/data/papers.ts
+++ b/src/data/papers.ts
@@ -9,6 +9,7 @@ export interface Paper {
   abstract: string
   externalUrl: string
   pdfUrl?: string
+  doi?: string // Digital Object Identifier (e.g., "10.1234/example.2025.001")
   repository: string
   publicationDate: string
   lastUpdated: string


### PR DESCRIPTION
## Summary
- Add CitationBlock component with APA, MLA, and BibTeX citation formats
- Add tabbed interface for switching between formats with copy functionality
- Add DOI field to Paper interface and ScholarlyArticle structured data schema

## Test plan
- [x] 22 CitationBlock tests pass
- [x] All 537 tests pass
- [x] Next.js build succeeds
- [x] Vite build succeeds
- [x] Lint passes

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)