### PR TITLE
feat(papers): Add social sharing buttons and enhanced SEO (#182)

### DIFF
--- a/app/components/ShareButtons.tsx
+++ b/app/components/ShareButtons.tsx
@@ -1,0 +1,137 @@
+/**
+ * ShareButtons Component
+ * Story 16.7c: Social sharing buttons
+ *
+ * Provides share buttons for Twitter/X, LinkedIn, and optionally email.
+ */
+
+interface ShareButtonsProps {
+  url: string
+  title: string
+  description?: string
+  showEmail?: boolean
+}
+
+function TwitterIcon() {
+  return (
+    <svg
+      data-testid="twitter-icon"
+      aria-hidden="true"
+      className="w-5 h-5"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  )
+}
+
+function LinkedInIcon() {
+  return (
+    <svg
+      data-testid="linkedin-icon"
+      aria-hidden="true"
+      className="w-5 h-5"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  )
+}
+
+function EmailIcon() {
+  return (
+    <svg
+      data-testid="email-icon"
+      aria-hidden="true"
+      className="w-5 h-5"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+      />
+    </svg>
+  )
+}
+
+function getTwitterShareUrl(url: string, title: string): string {
+  const params = new URLSearchParams({
+    url,
+    text: title,
+  })
+  return `https://twitter.com/intent/tweet?${params.toString()}`
+}
+
+function getLinkedInShareUrl(url: string): string {
+  const params = new URLSearchParams({
+    url,
+  })
+  return `https://www.linkedin.com/sharing/share-offsite/?${params.toString()}`
+}
+
+function getEmailShareUrl(url: string, title: string, description?: string): string {
+  const subject = title
+  const body = description
+    ? `${description}\n\nRead more: ${url}`
+    : `Check out this paper: ${url}`
+  return `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`
+}
+
+const ShareButtons = ({ url, title, description, showEmail = false }: ShareButtonsProps) => {
+  const twitterUrl = getTwitterShareUrl(url, title)
+  const linkedinUrl = getLinkedInShareUrl(url)
+  const emailUrl = getEmailShareUrl(url, title, description)
+
+  const buttonBaseClass =
+    'inline-flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors'
+
+  return (
+    <div
+      data-testid="share-buttons"
+      className="share-buttons print:hidden flex flex-wrap items-center gap-3"
+    >
+      <span className="text-sm font-medium text-gray-600">Share:</span>
+
+      <a
+        href={twitterUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${buttonBaseClass} text-gray-700 bg-gray-100 hover:bg-gray-200 hover:text-black`}
+        aria-label="Share on X (Twitter)"
+      >
+        <TwitterIcon />
+        <span className="sr-only sm:not-sr-only">X</span>
+      </a>
+
+      <a
+        href={linkedinUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${buttonBaseClass} text-[#0A66C2] bg-blue-50 hover:bg-blue-100`}
+        aria-label="Share on LinkedIn"
+      >
+        <LinkedInIcon />
+        <span className="sr-only sm:not-sr-only">LinkedIn</span>
+      </a>
+
+      {showEmail && (
+        <a
+          href={emailUrl}
+          className={`${buttonBaseClass} text-gray-700 bg-gray-100 hover:bg-gray-200`}
+          aria-label="Share via email"
+        >
+          <EmailIcon />
+          <span className="sr-only sm:not-sr-only">Email</span>
+        </a>
+      )}
+    </div>
+  )
+}
+
+export default ShareButtons

--- a/app/papers/[slug]/page.tsx
+++ b/app/papers/[slug]/page.tsx
@@ -10,6 +10,7 @@ import StructuredData from '../../components/StructuredData'
 import PdfDownloadButton from '../../components/PdfDownloadButton'
 import PaperHeader from '../../components/PaperHeader'
 import CitationBlock from '../../components/CitationBlock'
+import ShareButtons from '../../components/ShareButtons'
 import PrintButton from '../../components/PrintButton'
 import './print.css'
 
@@ -26,7 +27,7 @@ export async function generateStaticParams() {
     }))
 }
 
-// Generate metadata for each paper
+// Generate metadata for each paper with enhanced SEO
 export async function generateMetadata({ params }: PaperDetailProps): Promise<Metadata> {
   const { slug } = await params
   const paper = papers.find(p => p.slug === slug)
@@ -37,14 +38,52 @@ export async function generateMetadata({ params }: PaperDetailProps): Promise<Me
     }
   }
 
+  const paperUrl = `https://karstenwade.com/papers/${slug}`
+  const publicationYear = new Date(paper.publicationDate).getFullYear()
+
   return {
     title: `${paper.title} - Karsten Wade`,
     description: paper.abstract,
-    keywords: [...paper.tags, 'research paper', paper.category],
+    keywords: [...paper.tags, 'research paper', paper.category, 'Karsten Wade'],
+    authors: [{ name: 'Karsten Wade', url: 'https://karstenwade.com' }],
+    creator: 'Karsten Wade',
+    publisher: 'Karsten Wade',
     openGraph: {
+      type: 'article',
       title: paper.title,
       description: paper.abstract,
-      url: `https://karstenwade.com/papers/${slug}`,
+      url: paperUrl,
+      siteName: 'Karsten Wade',
+      locale: 'en_US',
+      publishedTime: paper.publicationDate,
+      modifiedTime: paper.lastUpdated,
+      authors: ['Karsten Wade'],
+      tags: paper.tags,
+      images: [
+        {
+          url: 'https://karstenwade.com/og-image-papers.png',
+          width: 1200,
+          height: 630,
+          alt: `${paper.title} - Paper by Karsten Wade`,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: paper.title,
+      description: paper.abstract,
+      creator: '@karstenwade',
+      images: ['https://karstenwade.com/og-image-papers.png'],
+    },
+    alternates: {
+      canonical: paperUrl,
+    },
+    other: {
+      'citation_title': paper.title,
+      'citation_author': 'Karsten Wade',
+      'citation_publication_date': paper.publicationDate,
+      'citation_year': publicationYear.toString(),
+      ...(paper.doi && { 'citation_doi': paper.doi }),
     },
   }
 }
@@ -223,6 +262,15 @@ export default async function PaperDetail({ params }: PaperDetailProps) {
 
           {/* Citation block - hidden in print */}
           <CitationBlock paper={paper} author="Karsten Wade" />
+
+          {/* Social sharing buttons - hidden in print */}
+          <div className="mt-6">
+            <ShareButtons
+              url={`https://karstenwade.com/papers/${paper.slug}`}
+              title={paper.title}
+              description={paper.abstract}
+            />
+          </div>
 
           {/* Footer */}
           <footer className="paper-detail__footer pt-6 border-t border-gray-200 mt-8">

--- a/app/papers/__tests__/ShareButtons.test.tsx
+++ b/app/papers/__tests__/ShareButtons.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ShareButtons Component Tests
+ * Story 16.7c: Add social sharing and SEO
+ *
+ * RED PHASE: Tests for social sharing buttons.
+ *
+ * Requirements:
+ * - Display Twitter/X and LinkedIn share buttons
+ * - Generate proper share URLs with title and URL
+ * - Accessible with proper labels
+ * - Hidden in print mode
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import ShareButtons from '../../components/ShareButtons'
+
+const mockProps = {
+  url: 'https://karstenwade.com/papers/test-paper',
+  title: 'Test Paper Title',
+  description: 'A test paper about testing',
+}
+
+describe('ShareButtons Component', () => {
+  describe('Rendering', () => {
+    it('renders Twitter/X share button', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      expect(screen.getByRole('link', { name: /share on (twitter|x)/i })).toBeInTheDocument()
+    })
+
+    it('renders LinkedIn share button', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      expect(screen.getByRole('link', { name: /share on linkedin/i })).toBeInTheDocument()
+    })
+
+    it('renders share section heading', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      expect(screen.getByText(/share/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Share URLs', () => {
+    it('generates correct Twitter share URL', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      const twitterLink = screen.getByRole('link', { name: /share on (twitter|x)/i })
+      const href = twitterLink.getAttribute('href')
+
+      expect(href).toContain('twitter.com/intent/tweet')
+      expect(href).toContain(encodeURIComponent(mockProps.url))
+      // URLSearchParams encodes spaces as + which is valid for query strings
+      expect(href).toContain('text=Test+Paper+Title')
+    })
+
+    it('generates correct LinkedIn share URL', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      const linkedinLink = screen.getByRole('link', { name: /share on linkedin/i })
+      const href = linkedinLink.getAttribute('href')
+
+      expect(href).toContain('linkedin.com/sharing/share-offsite')
+      expect(href).toContain(encodeURIComponent(mockProps.url))
+    })
+  })
+
+  describe('Link attributes', () => {
+    it('opens Twitter link in new tab', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      const twitterLink = screen.getByRole('link', { name: /share on (twitter|x)/i })
+      expect(twitterLink).toHaveAttribute('target', '_blank')
+      expect(twitterLink).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    })
+
+    it('opens LinkedIn link in new tab', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      const linkedinLink = screen.getByRole('link', { name: /share on linkedin/i })
+      expect(linkedinLink).toHaveAttribute('target', '_blank')
+      expect(linkedinLink).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('has accessible labels for screen readers', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      // Both buttons should have accessible names
+      expect(screen.getByRole('link', { name: /share on (twitter|x)/i })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: /share on linkedin/i })).toBeInTheDocument()
+    })
+
+    it('includes social icons with aria-hidden', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      const twitterIcon = screen.getByTestId('twitter-icon')
+      const linkedinIcon = screen.getByTestId('linkedin-icon')
+
+      expect(twitterIcon).toHaveAttribute('aria-hidden', 'true')
+      expect(linkedinIcon).toHaveAttribute('aria-hidden', 'true')
+    })
+  })
+
+  describe('Print behavior', () => {
+    it('is hidden in print mode', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      const shareButtons = screen.getByTestId('share-buttons')
+      expect(shareButtons).toHaveClass('print:hidden')
+    })
+  })
+
+  describe('Optional email sharing', () => {
+    it('renders email share button when showEmail is true', () => {
+      render(<ShareButtons {...mockProps} showEmail />)
+
+      expect(screen.getByRole('link', { name: /share via email/i })).toBeInTheDocument()
+    })
+
+    it('does not render email button by default', () => {
+      render(<ShareButtons {...mockProps} />)
+
+      expect(screen.queryByRole('link', { name: /share via email/i })).not.toBeInTheDocument()
+    })
+
+    it('generates correct email share URL', () => {
+      render(<ShareButtons {...mockProps} showEmail />)
+
+      const emailLink = screen.getByRole('link', { name: /share via email/i })
+      const href = emailLink.getAttribute('href')
+
+      expect(href).toContain('mailto:')
+      expect(href).toContain(encodeURIComponent(mockProps.title))
+      expect(href).toContain(encodeURIComponent(mockProps.url))
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Create ShareButtons component with Twitter/X and LinkedIn share buttons
- Add optional email sharing functionality
- Enhance meta tags with Open Graph, Twitter Card, and citation metadata
- Add canonical URLs and author/publisher metadata

## Changes
- **New**: `app/components/ShareButtons.tsx` - Social sharing buttons for Twitter/X, LinkedIn, and optional email
- **New**: `app/papers/__tests__/ShareButtons.test.tsx` - 13 unit tests for ShareButtons component
- **Modified**: `app/papers/[slug]/page.tsx` - Enhanced generateMetadata with comprehensive SEO tags and integrated ShareButtons

## Meta Tags Added
- Open Graph: type, siteName, locale, publishedTime, modifiedTime, authors, tags, images
- Twitter Card: summary_large_image, creator, images
- Citation tags: citation_title, citation_author, citation_publication_date, citation_year, citation_doi
- Canonical URL for SEO

## Test plan
- [x] ShareButtons renders Twitter/X and LinkedIn buttons
- [x] Share URLs are correctly generated with encoded parameters
- [x] Links open in new tabs with proper security attributes
- [x] Social icons have aria-hidden for accessibility
- [x] Component is hidden in print mode
- [x] Optional email button works when showEmail prop is true
- [x] All 550 tests pass
- [x] Build succeeds

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)